### PR TITLE
Update SEO page colors

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,5 @@
-import { defineConfig } from 'astro/config';
-import tailwind from '@astrojs/tailwind';
+import { defineConfig } from "astro/config";
+import tailwind from "@astrojs/tailwind";
 
 export default defineConfig({
   integrations: [tailwind()],

--- a/src/pages/servicios/seo.astro
+++ b/src/pages/servicios/seo.astro
@@ -9,20 +9,20 @@ const description = "SEO técnico y de contenido para negocios locales. Webs opt
 
 <Layout {title} {description}>
   <!-- Hero Section - Adaptado a SEO -->
-  <section class="py-20 px-6 bg-gradient-to-br from-purple-50 to-white">
+  <section class="py-20 px-6 bg-gradient-to-br from-indigo-50 to-white">
     <div class="container mx-auto max-w-6xl text-center">
       <h1 class="text-4xl md:text-5xl font-bold mb-6 text-gray-800">
-        SEO que <span class="block bg-clip-text text-transparent bg-gradient-to-r from-blue-600 to-cyan-600">genera clientes</span>
+        SEO que <span class="block bg-clip-text text-transparent bg-gradient-to-r from-indigo-600 to-fuchsia-600">genera clientes</span>
       </h1>
       <p class="text-xl text-gray-600 mb-10 max-w-3xl mx-auto">
-        No todos los negocios necesitan el mismo SEO. Creamos estrategias <strong class="text-blue-600">personalizadas</strong> según tu sector y objetivos reales.
+        No todos los negocios necesitan el mismo SEO. Creamos estrategias <strong class="text-indigo-600">personalizadas</strong> según tu sector y objetivos reales.
       </p>
       
       <div class="flex flex-wrap justify-center gap-4">
-        <a href="#planes" class="bg-gradient-to-r from-blue-500 to-cyan-600 hover:from-blue-600 hover:to-cyan-700 text-white font-bold py-3 px-8 rounded-lg transition shadow-md hover:shadow-lg">
+        <a href="#planes" class="bg-gradient-to-r from-indigo-500 to-fuchsia-600 hover:from-indigo-600 hover:to-fuchsia-700 text-white font-bold py-3 px-8 rounded-lg transition shadow-md hover:shadow-lg">
           Ver Planes SEO
         </a>
-        <a href="#importancia" class="bg-white hover:bg-gray-50 text-blue-700 font-bold py-3 px-8 rounded-lg transition border-2 border-blue-200 shadow-sm hover:shadow-md">
+        <a href="#importancia" class="bg-white hover:bg-gray-50 text-indigo-700 font-bold py-3 px-8 rounded-lg transition border-2 border-indigo-200 shadow-sm hover:shadow-md">
           ¿Por qué es importante?
         </a>
       </div>
@@ -34,7 +34,7 @@ const description = "SEO técnico y de contenido para negocios locales. Webs opt
     <div class="container mx-auto max-w-6xl">
       <div class="text-center mb-12">
         <h2 class="text-3xl md:text-4xl font-bold text-gray-800 mb-4">
-          SEO <span class="bg-clip-text text-transparent bg-gradient-to-r from-blue-600 to-cyan-600">según tu negocio</span>
+          SEO <span class="bg-clip-text text-transparent bg-gradient-to-r from-indigo-600 to-fuchsia-600">según tu negocio</span>
         </h2>
         <p class="text-lg text-gray-600 max-w-3xl mx-auto">
           No es lo mismo tener presencia online que competir por clientes
@@ -42,29 +42,29 @@ const description = "SEO técnico y de contenido para negocios locales. Webs opt
       </div>
 
       <div class="grid md:grid-cols-2 gap-8 items-center">
-        <div>
-          <div class="bg-blue-100 text-blue-800 font-bold inline-flex px-4 py-1 rounded-full mb-4 text-sm">
+        <div class="bg-gray-50 p-8 rounded-xl border border-gray-200">
+          <div class="bg-indigo-100 text-indigo-800 font-bold inline-flex px-4 py-1 rounded-full mb-4 text-sm">
             Para negocios con clientes locales
           </div>
           <h3 class="text-2xl font-bold text-gray-800 mb-4">Fontaneros, cerrajeros, pintores...</h3>
           <p class="text-gray-600 mb-6">
-            <strong class="text-blue-600">Tu web es tu principal fuente de clientes.</strong> La mayoría te encontrarán buscando "tu servicio + tu ciudad". Necesitas:
+            <strong class="text-indigo-600">Tu web es tu principal fuente de clientes.</strong> La mayoría te encontrarán buscando "tu servicio + tu ciudad". Necesitas:
           </p>
           <ul class="space-y-3">
             <li class="flex items-start">
-              <svg class="w-5 h-5 text-blue-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5 text-indigo-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
               </svg>
               <span>Posicionamiento en <strong>tus palabras clave principales</strong></span>
             </li>
             <li class="flex items-start">
-              <svg class="w-5 h-5 text-blue-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5 text-indigo-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
               </svg>
               <span>Optimización para <strong>búsquedas locales</strong> (Google My Business)</span>
             </li>
             <li class="flex items-start">
-              <svg class="w-5 h-5 text-blue-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5 text-indigo-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
               </svg>
               <span>Contenido <strong>geolocalizado</strong> (landing pages por zonas)</span>
@@ -72,28 +72,28 @@ const description = "SEO técnico y de contenido para negocios locales. Webs opt
           </ul>
         </div>
         <div class="bg-gray-50 p-8 rounded-xl border border-gray-200">
-          <div class="bg-blue-100 text-blue-800 font-bold inline-flex px-4 py-1 rounded-full mb-4 text-sm">
+          <div class="bg-indigo-100 text-indigo-800 font-bold inline-flex px-4 py-1 rounded-full mb-4 text-sm">
             Para negocios con clientes presenciales
           </div>
           <h3 class="text-2xl font-bold text-gray-800 mb-4">Restaurantes, peluquerías, tiendas...</h3>
           <p class="text-gray-600 mb-6">
-            <strong class="text-blue-600">Tu web refuerza tu presencia.</strong> La mayoría te conocerá por otros medios, pero necesitas:
+            <strong class="text-indigo-600">Tu web refuerza tu presencia.</strong> La mayoría te conocerá por otros medios, pero necesitas:
           </p>
           <ul class="space-y-3">
             <li class="flex items-start">
-              <svg class="w-5 h-5 text-blue-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5 text-indigo-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
               </svg>
               <span>Información clara <strong>fácil de encontrar</strong></span>
             </li>
             <li class="flex items-start">
-              <svg class="w-5 h-5 text-blue-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5 text-indigo-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
               </svg>
               <span>Optimización para <strong>primera impresión</strong></span>
             </li>
             <li class="flex items-start">
-              <svg class="w-5 h-5 text-blue-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-5 h-5 text-indigo-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
               </svg>
               <span><strong>Presencia en directorios</strong> locales</span>
@@ -109,7 +109,7 @@ const description = "SEO técnico y de contenido para negocios locales. Webs opt
     <div class="container mx-auto max-w-6xl">
       <div class="text-center mb-12">
         <h2 class="text-3xl md:text-4xl font-bold text-gray-800 mb-4">
-          Bases técnicas <span class="bg-clip-text text-transparent bg-gradient-to-r from-blue-600 to-cyan-600">imprescindibles</span>
+          Bases técnicas <span class="bg-clip-text text-transparent bg-gradient-to-r from-indigo-600 to-fuchsia-600">imprescindibles</span>
         </h2>
         <p class="text-lg text-gray-600 max-w-3xl mx-auto">
           Construimos tu web con los cimientos perfectos para el SEO
@@ -118,74 +118,74 @@ const description = "SEO técnico y de contenido para negocios locales. Webs opt
 
       <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
         <div class="bg-white p-8 rounded-xl border border-gray-200 hover:shadow-lg transition">
-          <div class="w-12 h-12 mb-4 rounded-full bg-blue-100 flex items-center justify-center text-blue-700">
+          <div class="w-12 h-12 mb-4 rounded-full bg-indigo-100 flex items-center justify-center text-indigo-700">
             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path>
             </svg>
           </div>
           <h3 class="text-xl font-bold mb-3 text-gray-800">Velocidad de carga</h3>
           <p class="text-gray-600">
-            Webs optimizadas para cargar en <strong class="text-blue-600">menos de 1 segundo</strong>, con puntuación perfecta en PageSpeed Insights. Google premia los sitios rápidos.
+            Webs optimizadas para cargar en <strong class="text-indigo-600">menos de 1 segundo</strong>, con puntuación perfecta en PageSpeed Insights. Google premia los sitios rápidos.
           </p>
         </div>
 
         <div class="bg-white p-8 rounded-xl border border-gray-200 hover:shadow-lg transition">
-          <div class="w-12 h-12 mb-4 rounded-full bg-blue-100 flex items-center justify-center text-blue-700">
+          <div class="w-12 h-12 mb-4 rounded-full bg-indigo-100 flex items-center justify-center text-indigo-700">
             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
             </svg>
           </div>
           <h3 class="text-xl font-bold mb-3 text-gray-800">Estructura semántica</h3>
           <p class="text-gray-600">
-            Código HTML5 perfectamente estructurado con <strong class="text-blue-600">etiquetas semánticas</strong>, schema markup y jerarquía de contenido clara para los buscadores.
+            Código HTML5 perfectamente estructurado con <strong class="text-indigo-600">etiquetas semánticas</strong>, schema markup y jerarquía de contenido clara para los buscadores.
           </p>
         </div>
 
         <div class="bg-white p-8 rounded-xl border border-gray-200 hover:shadow-lg transition">
-          <div class="w-12 h-12 mb-4 rounded-full bg-blue-100 flex items-center justify-center text-blue-700">
+          <div class="w-12 h-12 mb-4 rounded-full bg-indigo-100 flex items-center justify-center text-indigo-700">
             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z"></path>
             </svg>
           </div>
           <h3 class="text-xl font-bold mb-3 text-gray-800">Experiencia móvil</h3>
           <p class="text-gray-600">
-            Diseño <strong class="text-blue-600">mobile-first</strong> completamente adaptable. Google prioriza los sitios con buena experiencia en dispositivos móviles.
+            Diseño <strong class="text-indigo-600">mobile-first</strong> completamente adaptable. Google prioriza los sitios con buena experiencia en dispositivos móviles.
           </p>
         </div>
 
         <div class="bg-white p-8 rounded-xl border border-gray-200 hover:shadow-lg transition">
-          <div class="w-12 h-12 mb-4 rounded-full bg-blue-100 flex items-center justify-center text-blue-700">
+          <div class="w-12 h-12 mb-4 rounded-full bg-indigo-100 flex items-center justify-center text-indigo-700">
             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"></path>
             </svg>
           </div>
           <h3 class="text-xl font-bold mb-3 text-gray-800">Seguridad</h3>
           <p class="text-gray-600">
-            Certificado SSL, protección contra malware y <strong class="text-blue-600">cumplimiento RGPD</strong>. Factores esenciales para el posicionamiento actual.
+            Certificado SSL, protección contra malware y <strong class="text-indigo-600">cumplimiento RGPD</strong>. Factores esenciales para el posicionamiento actual.
           </p>
         </div>
 
         <div class="bg-white p-8 rounded-xl border border-gray-200 hover:shadow-lg transition">
-          <div class="w-12 h-12 mb-4 rounded-full bg-blue-100 flex items-center justify-center text-blue-700">
+          <div class="w-12 h-12 mb-4 rounded-full bg-indigo-100 flex items-center justify-center text-indigo-700">
             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
             </svg>
           </div>
           <h3 class="text-xl font-bold mb-3 text-gray-800">URLs optimizadas</h3>
           <p class="text-gray-600">
-            Estructura de enlaces <strong class="text-blue-600">limpia y descriptiva</strong>, con keywords estratégicas y fácil navegación para usuarios y bots.
+            Estructura de enlaces <strong class="text-indigo-600">limpia y descriptiva</strong>, con keywords estratégicas y fácil navegación para usuarios y bots.
           </p>
         </div>
 
         <div class="bg-white p-8 rounded-xl border border-gray-200 hover:shadow-lg transition">
-          <div class="w-12 h-12 mb-4 rounded-full bg-blue-100 flex items-center justify-center text-blue-700">
+          <div class="w-12 h-12 mb-4 rounded-full bg-indigo-100 flex items-center justify-center text-indigo-700">
             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
             </svg>
           </div>
           <h3 class="text-xl font-bold mb-3 text-gray-800">Contenido estratégico</h3>
           <p class="text-gray-600">
-            Textos originales con <strong class="text-blue-600">keywords naturales</strong>, meta tags personalizados y estructura de contenido optimizada para conversión.
+            Textos originales con <strong class="text-indigo-600">keywords naturales</strong>, meta tags personalizados y estructura de contenido optimizada para conversión.
           </p>
         </div>
       </div>
@@ -197,7 +197,7 @@ const description = "SEO técnico y de contenido para negocios locales. Webs opt
     <div class="container mx-auto max-w-6xl">
       <div class="text-center mb-12">
         <h2 class="text-3xl md:text-4xl font-bold text-gray-800 mb-4">
-          Mantenimiento <span class="bg-clip-text text-transparent bg-gradient-to-r from-blue-600 to-cyan-600">SEO continuo</span>
+          Mantenimiento <span class="bg-clip-text text-transparent bg-gradient-to-r from-indigo-600 to-fuchsia-600">SEO continuo</span>
         </h2>
         <p class="text-lg text-gray-600 max-w-3xl mx-auto">
           El SEO no termina cuando se lanza la web. Ofrecemos planes para mantener y mejorar tu posicionamiento.
@@ -209,82 +209,82 @@ const description = "SEO técnico y de contenido para negocios locales. Webs opt
         <div class="bg-gray-50 rounded-xl overflow-hidden border border-gray-200 hover:shadow-lg transition">
           <div class="p-8">
             <h3 class="text-2xl font-bold text-gray-800 mb-2">Plan Básico</h3>
-            <p class="text-blue-600 font-medium mb-4">Para mantener tu web actualizada</p>
+            <p class="text-indigo-600 font-medium mb-4">Para mantener tu web actualizada</p>
             <div class="flex items-end mb-6">
               <span class="text-4xl font-bold text-gray-800">30€</span>
               <span class="text-gray-500 ml-1">+IVA/mes</span>
             </div>
             <ul class="space-y-3 mb-8">
               <li class="flex items-start">
-                <svg class="w-5 h-5 text-blue-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-5 h-5 text-indigo-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                 </svg>
                 <span>Hosting y correo profesional</span>
               </li>
               <li class="flex items-start">
-                <svg class="w-5 h-5 text-blue-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-5 h-5 text-indigo-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                 </svg>
                 <span>Actualizaciones de seguridad</span>
               </li>
               <li class="flex items-start">
-                <svg class="w-5 h-5 text-blue-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-5 h-5 text-indigo-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                 </svg>
                 <span>Soporte técnico básico</span>
               </li>
               <li class="flex items-start">
-                <svg class="w-5 h-5 text-blue-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-5 h-5 text-indigo-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                 </svg>
                 <span>Backups semanales</span>
               </li>
             </ul>
-            <a href="#contacto" class="block w-full bg-white text-blue-700 font-bold py-3 px-6 rounded-lg transition border-2 border-blue-200 text-center hover:bg-blue-50">
+            <a href="#contacto" class="block w-full bg-white text-indigo-700 font-bold py-3 px-6 rounded-lg transition border-2 border-indigo-200 text-center hover:bg-indigo-50">
               Contratar
             </a>
           </div>
         </div>
 
         <!-- Plan Intermedio -->
-        <div class="bg-white rounded-xl overflow-hidden border-2 border-blue-500 shadow-lg relative">
-          <div class="absolute top-4 right-4 bg-blue-600 text-white text-xs font-bold px-3 py-1 rounded-full">
+        <div class="bg-white rounded-xl overflow-hidden border-2 border-indigo-500 shadow-lg relative">
+          <div class="absolute top-4 right-4 bg-indigo-600 text-white text-xs font-bold px-3 py-1 rounded-full">
             Más popular
           </div>
           <div class="p-8">
             <h3 class="text-2xl font-bold text-gray-800 mb-2">Plan Contenido</h3>
-            <p class="text-blue-600 font-medium mb-4">Para mejorar posicionamiento</p>
+            <p class="text-indigo-600 font-medium mb-4">Para mejorar posicionamiento</p>
             <div class="flex items-end mb-6">
               <span class="text-4xl font-bold text-gray-800">60€</span>
               <span class="text-gray-500 ml-1">+IVA/mes</span>
             </div>
             <ul class="space-y-3 mb-8">
               <li class="flex items-start">
-                <svg class="w-5 h-5 text-blue-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-5 h-5 text-indigo-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                 </svg>
                 <span><strong>Todas las ventajas del Plan Básico</strong></span>
               </li>
               <li class="flex items-start">
-                <svg class="w-5 h-5 text-blue-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-5 h-5 text-indigo-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                 </svg>
                 <span>1 artículo de blog/mes optimizado SEO</span>
               </li>
               <li class="flex items-start">
-                <svg class="w-5 h-5 text-blue-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-5 h-5 text-indigo-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                 </svg>
                 <span>Actualización de contenidos existentes</span>
               </li>
               <li class="flex items-start">
-                <svg class="w-5 h-5 text-blue-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-5 h-5 text-indigo-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                 </svg>
                 <span>Optimización de imágenes y metadatos</span>
               </li>
             </ul>
-            <a href="#contacto" class="block w-full bg-gradient-to-r from-blue-500 to-cyan-600 text-white font-bold py-3 px-6 rounded-lg transition shadow-md hover:shadow-lg text-center">
+            <a href="#contacto" class="block w-full bg-gradient-to-r from-indigo-500 to-fuchsia-600 text-white font-bold py-3 px-6 rounded-lg transition shadow-md hover:shadow-lg text-center">
               Contratar
             </a>
           </div>
@@ -294,44 +294,44 @@ const description = "SEO técnico y de contenido para negocios locales. Webs opt
         <div class="bg-gray-50 rounded-xl overflow-hidden border border-gray-200 hover:shadow-lg transition">
           <div class="p-8">
             <h3 class="text-2xl font-bold text-gray-800 mb-2">Plan Avanzado</h3>
-            <p class="text-blue-600 font-medium mb-4">Para crecimiento continuo</p>
+            <p class="text-indigo-600 font-medium mb-4">Para crecimiento continuo</p>
             <div class="flex items-end mb-6">
               <span class="text-4xl font-bold text-gray-800">200€</span>
               <span class="text-gray-500 ml-1">+IVA/mes</span>
             </div>
             <ul class="space-y-3 mb-8">
               <li class="flex items-start">
-                <svg class="w-5 h-5 text-blue-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-5 h-5 text-indigo-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                 </svg>
                 <span><strong>Todas las ventajas del Plan Contenido</strong></span>
               </li>
               <li class="flex items-start">
-                <svg class="w-5 h-5 text-blue-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-5 h-5 text-indigo-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                 </svg>
                 <span>4 artículos de blog/mes optimizados</span>
               </li>
               <li class="flex items-start">
-                <svg class="w-5 h-5 text-blue-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-5 h-5 text-indigo-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                 </svg>
                 <span>Investigación de keywords avanzada</span>
               </li>
               <li class="flex items-start">
-                <svg class="w-5 h-5 text-blue-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-5 h-5 text-indigo-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                 </svg>
                 <span>Informe mensual de posicionamiento</span>
               </li>
               <li class="flex items-start">
-                <svg class="w-5 h-5 text-blue-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-5 h-5 text-indigo-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                 </svg>
                 <span>Estrategia de enlaces internos</span>
               </li>
             </ul>
-            <a href="#contacto" class="block w-full bg-white text-blue-700 font-bold py-3 px-6 rounded-lg transition border-2 border-blue-200 text-center hover:bg-blue-50">
+            <a href="#contacto" class="block w-full bg-white text-indigo-700 font-bold py-3 px-6 rounded-lg transition border-2 border-indigo-200 text-center hover:bg-indigo-50">
               Contratar
             </a>
           </div>
@@ -341,12 +341,12 @@ const description = "SEO técnico y de contenido para negocios locales. Webs opt
   </section>
 
   <!-- CTA Final -->
-  <section id="contacto" class="py-16 px-6 bg-gradient-to-br from-blue-600 to-cyan-600">
+  <section id="contacto" class="py-16 px-6 bg-gradient-to-br from-indigo-600 to-fuchsia-600">
     <div class="container mx-auto max-w-4xl text-center">
       <h2 class="text-3xl md:text-4xl font-bold text-white mb-6">
         ¿Necesitas aparecer en Google cuando te buscan?
       </h2>
-      <p class="text-xl text-blue-100 mb-10 max-w-2xl mx-auto">
+      <p class="text-xl text-indigo-100 mb-10 max-w-2xl mx-auto">
         Analizamos tu competencia y te decimos <strong class="text-white">sin compromiso</strong> cómo mejorar tu posicionamiento.
       </p>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,4 +1,3 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,20 +1,17 @@
 // tailwind.config.js
 module.exports = {
-  content: [
-    './src/**/*.{astro,html,js,jsx,ts,tsx,vue,svelte}',
-  ],
+  content: ["./src/**/*.{astro,html,js,jsx,ts,tsx,vue,svelte}"],
   theme: {
     extend: {
-      display: ['group-hover'],
-      opacity: ['group-hover'],
-      transform: ['group-hover'],
+      display: ["group-hover"],
+      opacity: ["group-hover"],
+      transform: ["group-hover"],
       transitionDuration: {
-        '2000': '2000ms',
-        '3000': '3000ms',
-        '5000': '5000ms',
-      }
+        2000: "2000ms",
+        3000: "3000ms",
+        5000: "5000ms",
+      },
     },
   },
   plugins: [],
-}
-
+};


### PR DESCRIPTION
## Summary
- tweak SEO page color palette to match site branding
- run prettier formatting

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688cae8feb90832c8ee76025f99c1e27