### PR TITLE
Improve SEO maintenance plans layout

### DIFF
--- a/src/pages/servicios/seo.astro
+++ b/src/pages/servicios/seo.astro
@@ -193,7 +193,7 @@ const description = "SEO técnico y de contenido para negocios locales. Webs opt
   </section>
 
   <!-- Planes de mantenimiento SEO -->
-  <section id="planes" class="py-16 px-6 bg-white">
+  <section id="planes" class="py-16 px-6 bg-gradient-to-br from-white via-gray-50 to-white">
     <div class="container mx-auto max-w-6xl">
       <div class="text-center mb-12">
         <h2 class="text-3xl md:text-4xl font-bold text-gray-800 mb-4">
@@ -204,17 +204,17 @@ const description = "SEO técnico y de contenido para negocios locales. Webs opt
         </p>
       </div>
 
-      <div class="grid md:grid-cols-3 gap-6 max-w-5xl mx-auto">
+      <div class="grid gap-8 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 max-w-5xl mx-auto">
         <!-- Plan Básico -->
-        <div class="bg-gray-50 rounded-xl overflow-hidden border border-gray-200 hover:shadow-lg transition">
-          <div class="p-8">
+        <div class="flex flex-col h-full bg-white rounded-2xl border border-gray-200 shadow-sm hover:shadow-lg transition">
+          <div class="p-8 flex flex-col flex-grow">
             <h3 class="text-2xl font-bold text-gray-800 mb-2">Plan Básico</h3>
             <p class="text-indigo-600 font-medium mb-4">Para mantener tu web actualizada</p>
             <div class="flex items-end mb-6">
               <span class="text-4xl font-bold text-gray-800">30€</span>
               <span class="text-gray-500 ml-1">+IVA/mes</span>
             </div>
-            <ul class="space-y-3 mb-8">
+            <ul class="space-y-3 mb-8 flex-grow">
               <li class="flex items-start">
                 <svg class="w-5 h-5 text-indigo-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
@@ -247,18 +247,18 @@ const description = "SEO técnico y de contenido para negocios locales. Webs opt
         </div>
 
         <!-- Plan Intermedio -->
-        <div class="bg-white rounded-xl overflow-hidden border-2 border-indigo-500 shadow-lg relative">
+        <div class="relative flex flex-col h-full bg-white rounded-2xl border-2 border-indigo-500 shadow-lg">
           <div class="absolute top-4 right-4 bg-indigo-600 text-white text-xs font-bold px-3 py-1 rounded-full">
             Más popular
           </div>
-          <div class="p-8">
+          <div class="p-8 flex flex-col flex-grow">
             <h3 class="text-2xl font-bold text-gray-800 mb-2">Plan Contenido</h3>
             <p class="text-indigo-600 font-medium mb-4">Para mejorar posicionamiento</p>
             <div class="flex items-end mb-6">
               <span class="text-4xl font-bold text-gray-800">60€</span>
               <span class="text-gray-500 ml-1">+IVA/mes</span>
             </div>
-            <ul class="space-y-3 mb-8">
+            <ul class="space-y-3 mb-8 flex-grow">
               <li class="flex items-start">
                 <svg class="w-5 h-5 text-indigo-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
@@ -291,15 +291,15 @@ const description = "SEO técnico y de contenido para negocios locales. Webs opt
         </div>
 
         <!-- Plan Avanzado -->
-        <div class="bg-gray-50 rounded-xl overflow-hidden border border-gray-200 hover:shadow-lg transition">
-          <div class="p-8">
+        <div class="flex flex-col h-full bg-white rounded-2xl border border-gray-200 shadow-sm hover:shadow-lg transition">
+          <div class="p-8 flex flex-col flex-grow">
             <h3 class="text-2xl font-bold text-gray-800 mb-2">Plan Avanzado</h3>
             <p class="text-indigo-600 font-medium mb-4">Para crecimiento continuo</p>
             <div class="flex items-end mb-6">
               <span class="text-4xl font-bold text-gray-800">200€</span>
               <span class="text-gray-500 ml-1">+IVA/mes</span>
             </div>
-            <ul class="space-y-3 mb-8">
+            <ul class="space-y-3 mb-8 flex-grow">
               <li class="flex items-start">
                 <svg class="w-5 h-5 text-indigo-500 mt-0.5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>


### PR DESCRIPTION
## Summary
- enhance the SEO maintenance plans section styles for mobile and desktop

## Testing
- `npm run format`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_688cbcc329e0832c8244bc4d917a9d70