### PR TITLE
feat: reveal footer on scroll

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -2,7 +2,10 @@
 // src/components/Footer.astro
 ---
 
-<footer class="bg-gradient-to-br from-purple-900 to-slate-900 text-white pt-12 pb-6 px-6">
+<footer
+  id="site-footer"
+  class="fixed bottom-0 left-0 w-full bg-gradient-to-br from-purple-900 to-slate-900 text-white pt-12 pb-6 px-6 transform translate-y-full transition-transform duration-500 ease-out"
+>
   <div class="container mx-auto max-w-5xl">
     <div class="grid md:grid-cols-4 gap-8 mb-8">
       

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -13,12 +13,23 @@ const { title, description } = Astro.props;
 <head>
   <Head title={title} description={description} />
 </head>
-<body class="bg-white text-gray-800 min-h-screen flex flex-col">
+<body class="bg-white text-gray-800 min-h-screen flex flex-col relative">
   <Nav />
-  <main class="flex-grow">
+  <main class="flex-grow relative z-10">
     <slot />
+    <div id="footer-trigger" class="h-px"></div>
   </main>
   <Footer />
+  <script is:inline>
+    document.addEventListener('DOMContentLoaded', () => {
+      const footer = document.getElementById('site-footer');
+      const trigger = document.getElementById('footer-trigger');
+      const observer = new IntersectionObserver(([entry]) => {
+        footer.classList.toggle('translate-y-full', !entry.isIntersecting);
+      });
+      observer.observe(trigger);
+    });
+  </script>
 
   <!-- Schema.org JSON-LD -->
   <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- add intersection observer to reveal footer on scroll
- slide footer up from bottom with fixed positioning and transitions

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find configuration)
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_688db0b2b8a8832caabed97565007659