### PR TITLE
Make footer reveal from bottom on scroll

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -4,7 +4,7 @@
 
 <footer
   id="site-footer"
-  class="fixed bottom-0 left-0 w-full bg-gradient-to-br from-purple-900 to-slate-900 text-white pt-12 pb-6 px-6 transform translate-y-full transition-transform duration-500 ease-out"
+  class="sticky bottom-0 left-0 w-full bg-gradient-to-br from-purple-900 to-slate-900 text-white pt-12 pb-6 px-6"
 >
   <div class="container mx-auto max-w-5xl">
     <div class="grid md:grid-cols-4 gap-8 mb-8">

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -17,19 +17,8 @@ const { title, description } = Astro.props;
   <Nav />
   <main class="flex-grow relative z-10">
     <slot />
-    <div id="footer-trigger" class="h-px"></div>
   </main>
   <Footer />
-  <script is:inline>
-    document.addEventListener('DOMContentLoaded', () => {
-      const footer = document.getElementById('site-footer');
-      const trigger = document.getElementById('footer-trigger');
-      const observer = new IntersectionObserver(([entry]) => {
-        footer.classList.toggle('translate-y-full', !entry.isIntersecting);
-      });
-      observer.observe(trigger);
-    });
-  </script>
 
   <!-- Schema.org JSON-LD -->
   <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- Replace fixed footer animation with `sticky` positioning so it reveals progressively from the bottom
- Remove `IntersectionObserver` scroll script and sentinel div from layout

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_688db5797264832cb7d3cec80aedf0e6