### PR TITLE
refactor PlatformCard div class template

### DIFF
--- a/src/components/PlatformCard.astro
+++ b/src/components/PlatformCard.astro
@@ -12,9 +12,11 @@ const {
 } = Astro.props;
 ---
 
-<div class="h-full flex flex-col bg-white rounded-xl border 
-  {featured ? 'border-2 border-purple-500 shadow-lg' : 'border-gray-200'} 
-  overflow-hidden">
+<div
+  class={`h-full flex flex-col bg-white rounded-xl border ${
+    featured ? 'border-2 border-purple-500 shadow-lg' : 'border-gray-200'
+  } overflow-hidden`}
+>
   
   <!-- Cabecera con logo y espacio -->
   <div class="flex items-center px-6 pt-6 pb-2">


### PR DESCRIPTION
## Summary
- refactor PlatformCard's opening div to use a single template-string `class` attribute for conditional styling

## Testing
- `npm run format`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_688e72523c6c832cb90a45a74ef84752