### PR TITLE
Fix mobile services dropdown and contact card layout

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -99,10 +99,50 @@
       <a href="/" class="block py-2 text-gray-700 hover:text-purple-700"
         >Inicio</a
       >
-      <a
-        href="/servicios"
-        class="block py-2 text-gray-700 hover:text-purple-700">Servicios</a
-      >
+      <!-- Servicios con submenú -->
+      <div>
+        <button
+          id="mobile-services-btn"
+          class="flex w-full items-center justify-between py-2 text-gray-700 hover:text-purple-700"
+        >
+          Servicios
+          <svg
+            class="w-4 h-4 ml-1"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M19 9l-7 7-7-7"
+            ></path>
+          </svg>
+        </button>
+        <div id="mobile-services-menu" class="hidden pl-4">
+          <a
+            href="/servicios/diseno-web"
+            class="block py-2 text-gray-700 hover:text-purple-700"
+            >Diseño Web</a
+          >
+          <a
+            href="/servicios/ecommerce"
+            class="block py-2 text-gray-700 hover:text-purple-700"
+            >E-commerce</a
+          >
+          <a
+            href="/servicios/seo"
+            class="block py-2 text-gray-700 hover:text-purple-700"
+            >SEO</a
+          >
+          <a
+            href="/servicios/ads"
+            class="block py-2 text-gray-700 hover:text-purple-700"
+            >Publicidad (ADS)</a
+          >
+        </div>
+      </div>
       <a href="/sobre-mi" class="block py-2 text-gray-700 hover:text-purple-700"
         >Sobre Mí</a
       >
@@ -121,5 +161,12 @@
       const menu = document.getElementById("mobile-menu");
       menu.classList.toggle("hidden");
     });
+    // Script para el submenú de servicios en móvil
+    document
+      .getElementById("mobile-services-btn")
+      .addEventListener("click", function () {
+        const submenu = document.getElementById("mobile-services-menu");
+        submenu.classList.toggle("hidden");
+      });
   </script>
 </nav>

--- a/src/pages/contacto.astro
+++ b/src/pages/contacto.astro
@@ -23,7 +23,7 @@ const description = "Contacta con nuestro equipo para desarrollar tu proyecto we
   <!-- Sección de Métodos de Contacto -->
   <section class="py-16 px-6 bg-white">
     <div class="container mx-auto max-w-5xl">
-      <div class="grid md:grid-cols-3 gap-8">
+      <div class="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
         <!-- Teléfono -->
         <div class="bg-gray-50 p-8 rounded-xl border border-gray-200 text-center hover:shadow-lg transition">
           <div class="w-16 h-16 mx-auto mb-6 rounded-full bg-purple-100 flex items-center justify-center text-purple-700">


### PR DESCRIPTION
## Summary
- add collapsible Services submenu for mobile nav
- prevent contact cards from shrinking on tablets

## Testing
- `npm run format`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f500f0140832cb7003633330898e4