### PR TITLE
Prevent check icons from shrinking

### DIFF
--- a/src/components/BeneficioItem.astro
+++ b/src/components/BeneficioItem.astro
@@ -4,7 +4,7 @@ const { texto } = Astro.props;
 ---
 <li class="flex items-start">
   <svg
-    class="w-6 h-6 text-purple-500 mt-0.5 mr-2"
+    class="w-6 h-6 text-purple-500 mt-0.5 mr-2 flex-shrink-0"
     fill="none"
     stroke="currentColor"
     viewBox="0 0 24 24"

--- a/src/pages/servicios/ads.astro
+++ b/src/pages/servicios/ads.astro
@@ -104,7 +104,7 @@ const description =
               <ul class="space-y-3">
                 <li class="flex items-start">
                   <svg
-                    class="w-6 h-6 text-amber-700 mt-0.5 mr-2"
+                    class="w-6 h-6 text-amber-700 mt-0.5 mr-2 flex-shrink-0"
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
@@ -122,7 +122,7 @@ const description =
                 </li>
                 <li class="flex items-start">
                   <svg
-                    class="w-6 h-6 text-amber-700 mt-0.5 mr-2"
+                    class="w-6 h-6 text-amber-700 mt-0.5 mr-2 flex-shrink-0"
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
@@ -139,7 +139,7 @@ const description =
                 </li>
                 <li class="flex items-start">
                   <svg
-                    class="w-6 h-6 text-amber-700 mt-0.5 mr-2"
+                    class="w-6 h-6 text-amber-700 mt-0.5 mr-2 flex-shrink-0"
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
@@ -181,7 +181,7 @@ const description =
               <ul class="space-y-3">
                 <li class="flex items-start">
                   <svg
-                    class="w-6 h-6 text-amber-700 mt-0.5 mr-2"
+                    class="w-6 h-6 text-amber-700 mt-0.5 mr-2 flex-shrink-0"
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
@@ -199,7 +199,7 @@ const description =
                 </li>
                 <li class="flex items-start">
                   <svg
-                    class="w-6 h-6 text-amber-700 mt-0.5 mr-2"
+                    class="w-6 h-6 text-amber-700 mt-0.5 mr-2 flex-shrink-0"
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
@@ -216,7 +216,7 @@ const description =
                 </li>
                 <li class="flex items-start">
                   <svg
-                    class="w-6 h-6 text-amber-700 mt-0.5 mr-2"
+                    class="w-6 h-6 text-amber-700 mt-0.5 mr-2 flex-shrink-0"
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
@@ -260,7 +260,7 @@ const description =
             <div class="grid sm:grid-cols-2 gap-4">
               <div class="flex items-start">
                 <svg
-                  class="w-6 h-6 text-purple-500 mt-0.5 mr-2"
+                  class="w-6 h-6 text-purple-500 mt-0.5 mr-2 flex-shrink-0"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -277,7 +277,7 @@ const description =
               </div>
               <div class="flex items-start">
                 <svg
-                  class="w-6 h-6 text-purple-500 mt-0.5 mr-2"
+                  class="w-6 h-6 text-purple-500 mt-0.5 mr-2 flex-shrink-0"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -294,7 +294,7 @@ const description =
               </div>
               <div class="flex items-start">
                 <svg
-                  class="w-6 h-6 text-purple-500 mt-0.5 mr-2"
+                  class="w-6 h-6 text-purple-500 mt-0.5 mr-2 flex-shrink-0"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -312,7 +312,7 @@ const description =
               </div>
               <div class="flex items-start">
                 <svg
-                  class="w-6 h-6 text-purple-500 mt-0.5 mr-2"
+                  class="w-6 h-6 text-purple-500 mt-0.5 mr-2 flex-shrink-0"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"

--- a/src/pages/servicios/diseno-web.astro
+++ b/src/pages/servicios/diseno-web.astro
@@ -368,7 +368,7 @@ const description =
                   >
                     <li class="flex items-start">
                       <svg
-                        class="w-6 h-6 text-purple-500 mt-0.5 mr-2"
+                        class="w-6 h-6 text-purple-500 mt-0.5 mr-2 flex-shrink-0"
                         fill="none"
                         stroke="currentColor"
                         viewBox="0 0 24 24"


### PR DESCRIPTION
## Summary
- ensure check icons retain size on ads and diseno-web pages
- update BeneficioItem component to avoid SVG shrink

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_688f7a4ef828832cbbd5efec22f3ddb4