### PR TITLE
feat: enhance SEO metadata

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -1,23 +1,44 @@
 ---
-const { title, description } = Astro.props;
+const {
+  title,
+  description,
+  canonical,
+  image,
+  robots,
+  keywords,
+  type,
+  siteName,
+} = Astro.props;
 ---
 <Fragment set:head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content={description} />
+  {keywords && <meta name="keywords" content={keywords} />}
+  <meta name="robots" content={robots} />
+  <meta name="author" content="Páginas web a Medida" />
+  <link rel="canonical" href={canonical} />
+  <meta name="theme-color" content="#ffffff" />
   <title>{title} | Páginas web a Medida</title>
 
   <!-- Favicon -->
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 
-  <!-- Alpine JS -->
-  <script defer src="https://unpkg.com/@alpinejs/intersect@3.x.x/dist/cdn.min.js"></script>
-  <script src="https://unpkg.com/alpinejs" defer></script>
-
   <!-- OpenGraph -->
   <meta property="og:title" content={title} />
   <meta property="og:description" content={description} />
-  <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://paginasamedida.com" />
-  <meta property="og:image" content="https://paginasamedida.com/og-image.png" />
+  <meta property="og:type" content={type} />
+  <meta property="og:url" content={canonical} />
+  <meta property="og:image" content={image} />
+  <meta property="og:site_name" content={siteName} />
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content={title} />
+  <meta name="twitter:description" content={description} />
+  <meta name="twitter:image" content={image} />
+
+  <!-- Alpine JS -->
+  <script defer src="https://unpkg.com/@alpinejs/intersect@3.x.x/dist/cdn.min.js"></script>
+  <script src="https://unpkg.com/alpinejs" defer></script>
 </Fragment>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -5,13 +5,58 @@ import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
 import '../styles/global.css';
 
-const { title, description } = Astro.props;
+const {
+  title,
+  description,
+  canonical = new URL(Astro.url.pathname, Astro.site).toString(),
+  image = new URL('/og-image.png', Astro.site).toString(),
+  robots = 'index,follow',
+  keywords,
+  type = 'website',
+  siteName = 'Páginas web a Medida',
+  schema,
+} = Astro.props;
+
+const defaultSchema = {
+  "@context": "https://schema.org",
+  "@type": "ProfessionalService",
+  "name": siteName,
+  "url": canonical,
+  "logo": new URL('/logo.png', Astro.site).toString(),
+  "description": description,
+  "address": {
+    "@type": "PostalAddress",
+    "streetAddress": "Avenida Glasgow 156",
+    "addressLocality": "Nuevo Baztán",
+    "addressRegion": "Madrid",
+    "postalCode": "28514",
+    "addressCountry": "ES"
+  },
+  "telephone": "+34623962963",
+  "openingHours": "Mo-Fr 09:30-18:00",
+  "priceRange": "$$",
+  "sameAs": [
+    "https://linkedin.com/in/jordi-martinez-joyeux",
+    "https://github.com/Dolp175"
+  ]
+};
+
+const schemaData = schema ?? defaultSchema;
 ---
 
 <!DOCTYPE html>
 <html lang="es">
 <head>
-  <Head title={title} description={description} />
+  <Head
+    {title}
+    {description}
+    canonical={canonical}
+    image={image}
+    robots={robots}
+    {keywords}
+    {type}
+    siteName={siteName}
+  />
 </head>
 <body class="bg-white text-gray-800 min-h-screen flex flex-col relative">
   <Nav />
@@ -22,29 +67,7 @@ const { title, description } = Astro.props;
 
   <!-- Schema.org JSON-LD -->
   <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "ProfessionalService",
-      "name": "Páginas web a Medida",
-      "url": "https://paginasamedida.com",
-      "logo": "https://paginasamedida.com/logo.png",
-      "description": "Desarrollo de páginas web a medida para negocios y profesionales.",
-      "address": {
-        "@type": "PostalAddress",
-        "streetAddress": "Avenida Glasgow 156",
-        "addressLocality": "Nuevo Baztán",
-        "addressRegion": "Madrid",
-        "postalCode": "28514",
-        "addressCountry": "ES"
-      },
-      "telephone": "+34623962963",
-      "openingHours": "Mo-Fr 09:30-18:00",
-      "priceRange": "$$",
-      "sameAs": [
-        "https://linkedin.com/in/jordi-martinez-joyeux",
-        "https://github.com/Dolp175"
-      ]
-    }
+    {JSON.stringify(schemaData)}
   </script>
 </body>
 </html>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -4,9 +4,23 @@ import Layout from "../../layouts/Layout.astro";
 
 const title = "Blog | Páginas a Medida";
 const description = "Artículos y consejos sobre desarrollo web, SEO y tecnología. Próximamente disponible.";
+const canonical = new URL(Astro.url.pathname, Astro.site).toString();
+const keywords = "blog, desarrollo web, seo, tecnología";
+const schema = {
+  "@context": "https://schema.org",
+  "@type": "Blog",
+  url: canonical,
+  name: title,
+  description,
+  publisher: {
+    "@type": "Organization",
+    name: "Páginas web a Medida",
+    logo: new URL('/logo.png', Astro.site).toString()
+  }
+};
 ---
 
-<Layout {title} {description}>
+<Layout {title} {description} {canonical} {keywords} {schema}>
   <!-- Hero Section -->
   <section class="py-24 px-6 bg-gradient-to-br from-purple-900 to-slate-900 text-center">
     <div class="container mx-auto max-w-4xl">

--- a/src/pages/contacto.astro
+++ b/src/pages/contacto.astro
@@ -5,9 +5,10 @@ import ContactForm from "../components/ContactForm.astro";
 
 const title = "Contacto | Páginas a Medida";
 const description = "Contacta con nuestro equipo para desarrollar tu proyecto web. Teléfono, WhatsApp, email o formulario de contacto.";
+const keywords = "contacto, desarrollo web, páginas a medida";
 ---
 
-<Layout {title} {description}>
+<Layout {title} {description} {keywords}>
   <!-- Hero Section -->
   <section class="py-20 px-6 bg-gradient-to-br from-purple-900 to-slate-900 text-center">
     <div class="container mx-auto max-w-4xl">

--- a/src/pages/gracias.astro
+++ b/src/pages/gracias.astro
@@ -5,9 +5,10 @@ sitemap: false
 
 const title = "¡Gracias por contactarnos! | Páginas a Medida";
 const description = "Hemos recibido tu mensaje correctamente. Te responderemos en breve.";
+const keywords = "gracias, contacto recibido, páginas a medida";
 ---
 
-<Layout {title} {description}>
+<Layout {title} {description} {keywords}>
   <!-- Hero Section -->
   <section class="py-20 px-6 bg-gradient-to-br from-purple-900 to-slate-900 text-center">
     <div class="container mx-auto max-w-4xl">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,6 +7,7 @@ import ContactForm from "../components/ContactForm.astro";
 <Layout
   title="Inicio"
   description="Desarrollo de páginas web estáticas y dinámicas a medida."
+  keywords="desarrollo web, diseño web, páginas web a medida, seo, tailwind, astro"
 >
   <!-- Hero Section -->
   <section

--- a/src/pages/legal/aviso-legal.astro
+++ b/src/pages/legal/aviso-legal.astro
@@ -5,9 +5,10 @@ sitemap: false
 
 const title = "Aviso Legal y Condiciones Generales de Uso";
 const description = "Aviso legal y condiciones de uso del sitio web paginasamedida.com";
+const keywords = "aviso legal, condiciones de uso";
 ---
 
-<Layout {title} {description}>
+<Layout {title} {description} {keywords}>
   <section class="py-16 px-6 bg-white">
     <div class="container mx-auto max-w-4xl">
       <h1 class="text-3xl md:text-4xl font-bold mb-8 text-gray-800">

--- a/src/pages/legal/politica-cookies.astro
+++ b/src/pages/legal/politica-cookies.astro
@@ -5,9 +5,10 @@ sitemap: false
 
 const title = "Política de Cookies";
 const description = "Política de cookies de paginasamedida.com";
+const keywords = "política de cookies, cookies";
 ---
 
-<Layout {title} {description}>
+<Layout {title} {description} {keywords}>
   <section class="py-16 px-6 bg-white">
     <div class="container mx-auto max-w-4xl">
       <h1 class="text-3xl md:text-4xl font-bold mb-8 text-gray-800">

--- a/src/pages/legal/politica-privacidad.astro
+++ b/src/pages/legal/politica-privacidad.astro
@@ -5,9 +5,10 @@ sitemap: false
 
 const title = "Política de Privacidad";
 const description = "Política de privacidad y protección de datos de paginasamedida.com";
+const keywords = "política de privacidad, protección de datos";
 ---
 
-<Layout {title} {description}>
+<Layout {title} {description} {keywords}>
   <section class="py-16 px-6 bg-white">
     <div class="container mx-auto max-w-4xl">
       <h1 class="text-3xl md:text-4xl font-bold mb-8 text-gray-800">

--- a/src/pages/servicios/ads.astro
+++ b/src/pages/servicios/ads.astro
@@ -6,9 +6,10 @@ import ContactForm from "../../components/ContactForm.astro";
 const title = "Publicidad Digital Profesional | Páginas a Medida";
 const description =
   "Gestión experta de campañas digitales en Google Ads, Meta Ads y más. Maximizamos tu inversión publicitaria con estrategias data-driven.";
+const keywords = "publicidad digital, google ads, meta ads";
 ---
 
-<Layout {title} {description}>
+<Layout {title} {description} {keywords}>
   <!-- Hero Section - Morado/Dorado oscuro -->
   <section class="py-20 px-6 bg-gradient-to-br from-purple-50 to-amber-50">
     <div class="container mx-auto max-w-6xl text-center">

--- a/src/pages/servicios/diseno-web.astro
+++ b/src/pages/servicios/diseno-web.astro
@@ -7,9 +7,10 @@ import BeneficioItem from "../../components/BeneficioItem.astro";
 const title = "Diseño Web Profesional | Páginas a Medida";
 const description =
   "Desarrollo de páginas web estáticas y dinámicas ultra rápidas con Astro y Tailwind, optimizadas para SEO y conversión.";
+const keywords = "diseño web, desarrollo web a medida, astro, tailwind";
 ---
 
-<Layout {title} {description}>
+<Layout {title} {description} {keywords}>
   <!-- Hero Section -->
   <section class="py-20 px-6 bg-gradient-to-br from-purple-50 to-white">
     <div class="container mx-auto max-w-6xl text-center">

--- a/src/pages/servicios/ecommerce.astro
+++ b/src/pages/servicios/ecommerce.astro
@@ -8,9 +8,10 @@ import FeatureCard from "../../components/FeatureCard.astro";
 const title = "Desarrollo Ecommerce Profesional | Páginas a Medida";
 const description =
   "Tiendas online a medida con Shopify, PrestaShop o WooCommerce. Soluciones optimizadas para conversión y gestión sencilla.";
+const keywords = "tiendas online, ecommerce, shopify, prestashop, woocommerce";
 ---
 
-<Layout {title} {description}>
+<Layout {title} {description} {keywords}>
   <!-- Hero Section -->
   <section class="py-20 px-6 bg-gradient-to-br from-purple-50 to-white">
     <div class="container mx-auto max-w-6xl text-center">

--- a/src/pages/servicios/seo.astro
+++ b/src/pages/servicios/seo.astro
@@ -6,9 +6,10 @@ import ContactForm from "../../components/ContactForm.astro";
 const title = "Posicionamiento SEO Profesional | Páginas a Medida";
 const description =
   "SEO técnico y de contenido para negocios locales. Webs optimizadas para aparecer en Google cuando tus clientes te buscan.";
+const keywords = "seo, posicionamiento web, marketing digital";
 ---
 
-<Layout {title} {description}>
+<Layout {title} {description} {keywords}>
   <!-- Hero Section - Adaptado a SEO -->
   <section class="py-20 px-6 bg-gradient-to-br from-indigo-50 to-white">
     <div class="container mx-auto max-w-6xl text-center">

--- a/src/pages/sobre-mi.astro
+++ b/src/pages/sobre-mi.astro
@@ -5,9 +5,10 @@ import Layout from "../layouts/Layout.astro";
 const title = "Sobre Mí | Ingeniero Informático Especializado";
 const description =
   "Ingeniero informático con más de 10 años de experiencia, especializado en desarrollo web y análisis de datos. Soluciones digitales con enfoque en resultados.";
+const keywords = "ingeniero informático, desarrollo web, análisis de datos";
 ---
 
-<Layout {title} {description}>
+<Layout {title} {description} {keywords}>
  <!-- Hero Section -->
   <section class="py-20 px-6 bg-gradient-to-br from-purple-900 to-slate-900 text-center">
     <div class="container mx-auto max-w-4xl">


### PR DESCRIPTION
## Summary
- expand Head component with canonical, robots, social and other modern SEO meta tags
- make layout compute per-page canonical URLs and JSON-LD schema dynamically
- allow pages to supply keywords and custom schema metadata

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688fd539d848832cac1cabc41cd5ee00