### PR TITLE
Add test posts and refine blog pagination nav

### DIFF
--- a/src/content/blog/post-prueba-dos.md
+++ b/src/content/blog/post-prueba-dos.md
@@ -1,0 +1,11 @@
+---
+title: "Post de Prueba Dos"
+description: "Segundo post de prueba para probar la paginación del blog."
+summary: "Otro artículo ficticio para asegurar que la segunda página del blog se genere."
+date: 2024-03-10
+image: /posts/tailwind-beneficios.webp
+thumbnail: /thumbs/tailwind-beneficios.webp
+readingTime: "2 min de lectura"
+---
+
+Contenido de prueba del segundo nuevo post.

--- a/src/content/blog/post-prueba-uno.md
+++ b/src/content/blog/post-prueba-uno.md
@@ -1,0 +1,11 @@
+---
+title: "Post de Prueba Uno"
+description: "Un artículo de prueba para verificar la paginación del blog."
+summary: "Este es un post de prueba para comprobar la funcionalidad de la paginación."
+date: 2024-04-15
+image: /posts/seo2024.webp
+thumbnail: /thumbs/seo2024.webp
+readingTime: "1 min de lectura"
+---
+
+Contenido de prueba del primer nuevo post.

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -6,6 +6,7 @@ const posts = await getSortedPosts();
 const postsPerPage = 6;
 const pagePosts = posts.slice(0, postsPerPage);
 const totalPages = Math.ceil(posts.length / postsPerPage);
+const currentPage = 1;
 const title = "Blog | Páginas a Medida";
 const description = "Artículos y consejos sobre desarrollo web, SEO y tecnología.";
 const canonical = new URL(Astro.url.pathname, Astro.site).toString();
@@ -39,7 +40,8 @@ const keywords = "blog, desarrollo web, seo, tecnología";
           {Array.from({ length: totalPages }).map((_, i) => (
             <a
               href={i === 0 ? '/blog/' : `/blog/page/${i + 1}/`}
-              class={`px-4 py-2 rounded ${i === 0 ? 'bg-purple-600 text-white' : 'bg-gray-200 text-gray-700 hover:bg-gray-300'}`}
+              class={`px-4 py-2 rounded ${i + 1 === currentPage ? 'bg-purple-600 text-white' : 'bg-gray-200 text-gray-700 hover:bg-gray-300'}`}
+              aria-current={i + 1 === currentPage ? 'page' : undefined}
             >
               {i + 1}
             </a>

--- a/src/pages/blog/page/[page].astro
+++ b/src/pages/blog/page/[page].astro
@@ -58,6 +58,7 @@ const keywords = "blog, desarrollo web, seo, tecnología";
             <a
               href={i === 0 ? '/blog/' : `/blog/page/${i + 1}/`}
               class={`px-4 py-2 rounded ${i + 1 === currentPage ? 'bg-purple-600 text-white' : 'bg-gray-200 text-gray-700 hover:bg-gray-300'}`}
+              aria-current={i + 1 === currentPage ? 'page' : undefined}
             >
               {i + 1}
             </a>


### PR DESCRIPTION
## Summary
- add two sample blog posts for pagination testing
- highlight active page and add `aria-current` to blog pagination links

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fec7e47fc832c94338d1f85646022