### PR TITLE
Improve blog article styling and add LatestPosts tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "preview": "astro preview",
     "astro": "astro",
     "format": "prettier --write .",
-    "lint": "eslint . --ext .js,.jsx,.ts,.tsx,.astro"
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx,.astro",
+    "test": "vitest"
   },
   "dependencies": {
     "@astrojs/mdx": "^4.3.3",
@@ -24,6 +25,9 @@
     "eslint-plugin-astro": "^1.3.1",
     "postcss": "^8.5.6",
     "prettier": "^3.6.2",
-    "tailwindcss": "^3.4.17"
+    "tailwindcss": "^3.4.17",
+    "vitest": "^1.5.0",
+    "@astrojs/test": "^2.1.3",
+    "@astrojs/vitest": "^1.1.0"
   }
 }

--- a/src/components/BlogSection.astro
+++ b/src/components/BlogSection.astro
@@ -8,7 +8,7 @@ interface Props {
 const { title } = Astro.props as Props;
 const id = slugify(title);
 ---
-<section id={id} class="mb-8">
-  <h2 class="text-2xl font-bold mb-4">{title}</h2>
+<section id={id} class="mb-8 bg-purple-50 p-6 rounded-lg shadow-sm">
+  <h2 class="text-2xl font-bold mb-4 text-purple-800">{title}</h2>
   <slot />
 </section>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -4,7 +4,7 @@
 
 <footer
   id="site-footer"
-  class="sticky bottom-0 left-0 w-full bg-gradient-to-br from-purple-900 to-slate-900 text-white pt-12 pb-6 px-6"
+  class="w-full bg-gradient-to-br from-purple-900 to-slate-900 text-white pt-12 pb-6 px-6 mt-auto"
 >
   <div class="container mx-auto max-w-5xl">
     <div class="grid md:grid-cols-4 gap-8 mb-8">

--- a/src/components/LatestPosts.test.ts
+++ b/src/components/LatestPosts.test.ts
@@ -1,0 +1,14 @@
+import { render } from '@astrojs/test';
+import { expect, test } from 'vitest';
+import LatestPosts from './LatestPosts.astro';
+
+test('renders LatestPosts heading', async () => {
+  const { container } = await render(LatestPosts);
+  expect(container.querySelector('h2')?.textContent).toContain('Últimos');
+});
+
+test('shows three articles', async () => {
+  const { container } = await render(LatestPosts);
+  const articles = container.querySelectorAll('article');
+  expect(articles.length).toBe(3);
+});

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -17,7 +17,7 @@ const canonical = new URL(Astro.url.pathname, Astro.site).toString();
 ---
 
 <Layout {title} {description} {canonical}>
-  <article class="prose lg:prose-lg max-w-3xl mx-auto py-16 px-6">
+  <article class="prose lg:prose-lg max-w-3xl mx-auto py-16 px-6 bg-gradient-to-b from-white to-purple-50 rounded-xl shadow-sm prose-headings:text-purple-800 prose-a:text-purple-600">
     <header class="mb-8">
       <h1 class="text-4xl font-bold text-gray-800 mb-4">{title}</h1>
       <img src={image} alt={title} class="w-full rounded-xl mb-6" />

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import astro from '@astrojs/vitest';
+
+export default defineConfig({
+  plugins: [astro()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+});


### PR DESCRIPTION
## Summary
- Refined article layout with gradient background and section highlights
- Made footer static with flexbox support
- Added tests for LatestPosts component and vitest config

## Testing
- `npm install` *(fails: 403 Forbidden for @astrojs/test)*
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: ESLint couldn't find eslint.config.*)*

------
https://chatgpt.com/codex/tasks/task_e_6890c019337c832ca110fd141ca011c9