### PR TITLE
fix blog features

### DIFF
--- a/src/components/BlogFooter.astro
+++ b/src/components/BlogFooter.astro
@@ -1,17 +1,35 @@
 ---
+interface Props {
+  url: string;
+  title: string;
+}
+
+const { url, title } = Astro.props as Props;
+const encodedUrl = encodeURIComponent(url);
+const encodedTitle = encodeURIComponent(title);
 ---
 <div class="max-w-4xl mx-auto px-6 mt-16 pt-8 border-t border-purple-100">
   <div class="bg-purple-50 rounded-xl p-8 text-center">
     <h3 class="text-xl font-bold text-purple-800 mb-4">¿Te ha resultado útil este artículo?</h3>
     <p class="text-gray-600 mb-6">Compártelo con otros profesionales que puedan necesitarlo</p>
     <div class="flex justify-center gap-4">
-      <a href="#" class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg flex items-center gap-2">
+      <a
+        href={`https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg flex items-center gap-2"
+      >
         <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
           <path d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878v-6.987h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12z"></path>
         </svg>
         Compartir
       </a>
-      <a href="#" class="bg-gray-800 hover:bg-gray-900 text-white px-4 py-2 rounded-lg flex items-center gap-2">
+      <a
+        href={`https://twitter.com/intent/tweet?url=${encodedUrl}&text=${encodedTitle}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="bg-gray-800 hover:bg-gray-900 text-white px-4 py-2 rounded-lg flex items-center gap-2"
+      >
         <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
           <path d="M8.29 20.251c7.547 0 11.675-6.253 11.675-11.675 0-.178 0-.355-.012-.53A8.348 8.348 0 0022 5.92a8.19 8.19 0 01-2.357.646 4.118 4.118 0 001.804-2.27 8.224 8.224 0 01-2.605.996 4.107 4.107 0 00-6.993 3.743 11.65 11.65 0 01-8.457-4.287 4.106 4.106 0 001.27 5.477A4.072 4.072 0 012.8 9.713v.052a4.105 4.105 0 003.292 4.022 4.095 4.095 0 01-1.853.07 4.108 4.108 0 003.834 2.85A8.233 8.233 0 012 18.407a11.616 11.616 0 006.29 1.84"></path>
         </svg>
@@ -19,7 +37,7 @@
       </a>
     </div>
   </div>
-  
+
   <div class="mt-12 text-center">
     <a href="/blog" class="inline-flex items-center text-purple-600 hover:text-purple-800 font-medium">
       <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -29,3 +47,4 @@
     </a>
   </div>
 </div>
+

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,10 +1,14 @@
 ---
 // src/components/Footer.astro
+const { sticky = true } = Astro.props as { sticky?: boolean };
+const baseClasses =
+  'w-full bg-gradient-to-br from-purple-900 to-slate-900 text-white pt-12 pb-6 px-6';
+const positionClasses = sticky ? 'sticky bottom-0 left-0' : '';
 ---
 
 <footer
   id="site-footer"
-  class="sticky bottom-0 left-0 w-full bg-gradient-to-br from-purple-900 to-slate-900 text-white pt-12 pb-6 px-6"
+  class={`${positionClasses} ${baseClasses}`}
 >
   <div class="container mx-auto max-w-5xl">
     <div class="grid md:grid-cols-4 gap-8 mb-8">

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -15,6 +15,7 @@ const {
   type = 'website',
   siteName = 'Páginas web a Medida',
   schema,
+  footerSticky = true,
 } = Astro.props;
 
 const defaultSchema = {
@@ -63,7 +64,7 @@ const schemaData = schema ?? defaultSchema;
   <main class="flex-grow relative z-10">
     <slot />
   </main>
-  <Footer />
+  <Footer sticky={footerSticky} />
 
   <!-- Schema.org JSON-LD -->
   <script type="application/ld+json">

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -13,13 +13,15 @@ export async function getStaticPaths() {
   }));
 }
 
-const { post } = Astro.props as { post: Awaited<ReturnType<typeof getCollection>>[number] };
-const { Content } = await post.render();
+const { post } = Astro.props as {
+  post: Awaited<ReturnType<typeof getCollection>>[number];
+};
+const { Content, headings } = await post.render();
 const { title, description, date, image, readingTime } = post.data;
 const canonical = new URL(Astro.url.pathname, Astro.site).toString();
 ---
 
-<Layout {title} {description} {canonical}>
+<Layout {title} {description} {canonical} footerSticky={false}>
   <article class="max-w-4xl mx-auto pb-16">
     <BlogHeader 
       title={title} 
@@ -34,10 +36,10 @@ const canonical = new URL(Astro.url.pathname, Astro.site).toString();
       </main>
       
       <aside class="hidden lg:block sticky top-8 h-min">
-        <BlogTOC content={Content} />
+        <BlogTOC headings={headings} />
       </aside>
     </div>
-    
-    <BlogFooter />
+
+    <BlogFooter url={canonical} title={title} />
   </article>
 </Layout>


### PR DESCRIPTION
## Summary
- fix toc rendering by using headings data
- add real share links in blog footer
- allow disabling sticky footer for posts

## Testing
- `npx prettier -w src/layouts/Layout.astro src/components/Footer.astro src/components/BlogFooter.astro src/pages/blog/[slug].astro src/components/BlogTOC.astro --ignore-unknown`
- `npm test` *(fails: Cannot find package '@astrojs/vitest')*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68913cee4518832c890b00484d48faa9