### PR TITLE
feat: add temas and mobile toc

### DIFF
--- a/src/components/BlogTOC.astro
+++ b/src/components/BlogTOC.astro
@@ -64,3 +64,4 @@ const { headings = [] } = Astro.props;
     </div>
   </div>
 </nav>
+

--- a/src/components/LatestPosts.astro
+++ b/src/components/LatestPosts.astro
@@ -39,7 +39,9 @@ const posts = (await getSortedPosts()).slice(0, 3);
                 <div class="p-6 flex-grow flex flex-col">
                   <div class="flex items-center gap-2 mb-3">
                     <span class="text-xs font-medium px-2 py-1 bg-purple-100 text-purple-700 rounded-full">
-                      {post.data.category}
+                      {Array.isArray(post.data.tema)
+                        ? post.data.tema.join(', ')
+                        : post.data.tema}
                     </span>
                     <span class="text-xs text-gray-500">
                       {new Date(post.data.date).toLocaleDateString('es-ES', { year: 'numeric', month: 'long', day: 'numeric' })}
@@ -88,7 +90,9 @@ const posts = (await getSortedPosts()).slice(0, 3);
               <div class="p-6 flex-grow flex flex-col">
                 <div class="flex items-center gap-2 mb-3">
                   <span class="text-xs font-medium px-2 py-1 bg-purple-100 text-purple-700 rounded-full">
-                    {post.data.category}
+                    {Array.isArray(post.data.tema)
+                      ? post.data.tema.join(', ')
+                      : post.data.tema}
                   </span>
                   <span class="text-xs text-gray-500">
                     {new Date(post.data.date).toLocaleDateString('es-ES', { year: 'numeric', month: 'long', day: 'numeric' })}

--- a/src/content/blog/seo-y-rendimiento.mdx
+++ b/src/content/blog/seo-y-rendimiento.mdx
@@ -7,6 +7,7 @@ date: 2025-08-03
 image: /posts/250803.webp
 thumbnail: /thumbs/250803.webp
 readingTime: "8 min de lectura"
+tema: ["SEO"]
 ---
 
 import BlogCallout from "../../components/BlogCallout.astro";

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -10,6 +10,7 @@ const blog = defineCollection({
     image: z.string(),
     thumbnail: z.string(),
     readingTime: z.string(),
+    tema: z.union([z.string(), z.array(z.string())]),
   }),
 });
 

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -4,3 +4,16 @@ export async function getSortedPosts(): Promise<CollectionEntry<'blog'>[]> {
   const posts = await getCollection('blog');
   return posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
 }
+
+export async function getPostsByTema(
+  tema: string,
+): Promise<CollectionEntry<'blog'>[]> {
+  const posts = await getCollection('blog', post => {
+    const temaData = post.data.tema;
+    if (Array.isArray(temaData)) {
+      return temaData.map(t => t.toLowerCase()).includes(tema.toLowerCase());
+    }
+    return temaData?.toLowerCase() === tema.toLowerCase();
+  });
+  return posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
+}

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -31,13 +31,13 @@ const canonical = new URL(Astro.url.pathname, Astro.site).toString();
     />
     
     <div class="grid lg:grid-cols-[1fr_250px] gap-8 px-6">
-      <main class="prose lg:prose-lg prose-headings:font-bold prose-headings:text-purple-800 prose-a:text-purple-600 hover:prose-a:text-purple-800 prose-blockquote:border-l-purple-600 prose-blockquote:bg-purple-50 prose-blockquote:px-6 prose-blockquote:py-4 prose-blockquote:rounded-r-lg max-w-none">
+      <div class="order-first lg:order-last">
+        <BlogTOC headings={headings} />
+      </div>
+
+      <main class="order-last lg:order-first prose lg:prose-lg prose-headings:font-bold prose-headings:text-purple-800 prose-a:text-purple-600 hover:prose-a:text-purple-800 prose-blockquote:border-l-purple-600 prose-blockquote:bg-purple-50 prose-blockquote:px-6 prose-blockquote:py-4 prose-blockquote:rounded-r-lg max-w-none">
         <Content />
       </main>
-      
-      <aside class="hidden lg:block sticky top-8 h-min">
-        <BlogTOC headings={headings} />
-      </aside>
     </div>
 
     <BlogFooter url={canonical} title={title} />

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -50,7 +50,9 @@ const keywords = "blog, desarrollo web, seo, tecnología";
               <div class="p-6 flex-grow flex flex-col">
                 <div class="flex items-center gap-2 mb-3">
                   <span class="text-xs font-medium px-2 py-1 bg-purple-100 text-purple-700 rounded-full">
-                    {post.data.category || 'Desarrollo Web'}
+                    {Array.isArray(post.data.tema)
+                      ? post.data.tema.join(', ')
+                      : post.data.tema || 'Desarrollo Web'}
                   </span>
                   <span class="text-xs text-gray-500">
                     {post.data.date.toLocaleDateString('es-ES', { year: 'numeric', month: 'long', day: 'numeric' })}


### PR DESCRIPTION
## Summary
- display BlogTOC on mobile
- add `tema` attribute to blog posts
- expose helper to filter posts by theme

## Testing
- `npm test` *(fails: Cannot find package '@astrojs/vitest')*
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6892727e2b48832ca19e7e6d2670e5b3