### PR TITLE
refactor: scope h2 bullet to blog

### DIFF
--- a/src/components/LatestPosts.astro
+++ b/src/components/LatestPosts.astro
@@ -41,7 +41,7 @@ const posts = (await getSortedPosts()).slice(0, 3);
                     <span class="text-xs font-medium px-2 py-1 bg-purple-100 text-purple-700 rounded-full">
                       {Array.isArray(post.data.tema)
                         ? post.data.tema.join(', ')
-                        : post.data.tema}
+                        : post.data.tema || 'Desarrollo Web'}
                     </span>
                     <span class="text-xs text-gray-500">
                       {new Date(post.data.date).toLocaleDateString('es-ES', { year: 'numeric', month: 'long', day: 'numeric' })}
@@ -92,7 +92,7 @@ const posts = (await getSortedPosts()).slice(0, 3);
                   <span class="text-xs font-medium px-2 py-1 bg-purple-100 text-purple-700 rounded-full">
                     {Array.isArray(post.data.tema)
                       ? post.data.tema.join(', ')
-                      : post.data.tema}
+                      : post.data.tema || 'Desarrollo Web'}
                   </span>
                   <span class="text-xs text-gray-500">
                     {new Date(post.data.date).toLocaleDateString('es-ES', { year: 'numeric', month: 'long', day: 'numeric' })}

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -35,7 +35,7 @@ const canonical = new URL(Astro.url.pathname, Astro.site).toString();
         <BlogTOC headings={headings} />
       </div>
 
-      <main class="order-last lg:order-first prose lg:prose-lg prose-headings:font-bold prose-headings:text-purple-800 prose-a:text-purple-600 hover:prose-a:text-purple-800 prose-blockquote:border-l-purple-600 prose-blockquote:bg-purple-50 prose-blockquote:px-6 prose-blockquote:py-4 prose-blockquote:rounded-r-lg max-w-none">
+        <main class="order-last lg:order-first prose prose-blog lg:prose-lg prose-headings:font-bold prose-headings:text-purple-800 prose-a:text-purple-600 hover:prose-a:text-purple-800 prose-blockquote:border-l-purple-600 prose-blockquote:bg-purple-50 prose-blockquote:px-6 prose-blockquote:py-4 prose-blockquote:rounded-r-lg max-w-none">
         <Content />
       </main>
     </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,7 +9,7 @@ module.exports = {
         5000: "5000ms",
       },
       typography: (theme) => ({
-        DEFAULT: {
+        blog: {
           css: {
             h2: {
               display: 'flex',


### PR DESCRIPTION
## Summary
- limit decorative h2 bullet styling to blog posts
- ensure blog posts keep bullet styling
- add fallback label for missing post topics

## Testing
- `npm test` *(fails: Cannot find package '@astrojs/vitest')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68927bab94c8832c9ab8049bf1db8945