### PR TITLE
feat: improve meta tags and blog schema

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -31,12 +31,17 @@ const {
   <meta property="og:url" content={canonical} />
   <meta property="og:image" content={image} />
   <meta property="og:site_name" content={siteName} />
+  <meta property="og:locale" content="es_ES" />
+  <meta property="og:image:alt" content={description} />
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content={title} />
   <meta name="twitter:description" content={description} />
   <meta name="twitter:image" content={image} />
+  <meta name="twitter:image:alt" content={description} />
+  <meta name="twitter:site" content="@PaginasAMedida" />
+  <meta name="twitter:creator" content="@PaginasAMedida" />
 
   <!-- Alpine JS -->
   <script defer src="https://unpkg.com/@alpinejs/intersect@3.x.x/dist/cdn.min.js"></script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -42,7 +42,15 @@ const defaultSchema = {
   ]
 };
 
-const schemaData = schema ?? defaultSchema;
+let schemaData;
+
+if (schema) {
+  schemaData = Array.isArray(schema)
+    ? [defaultSchema, ...schema]
+    : [defaultSchema, schema];
+} else {
+  schemaData = defaultSchema;
+}
 ---
 
 <!DOCTYPE html>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -19,9 +19,23 @@ const { post } = Astro.props as {
 const { Content, headings } = await post.render();
 const { title, description, date, image, readingTime } = post.data;
 const canonical = new URL(Astro.url.pathname, Astro.site).toString();
+const blogSchema = {
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": title,
+  "image": new URL(image, Astro.site).toString(),
+  "author": {
+    "@type": "Person",
+    "name": "Jordi Martínez Joyeux",
+  },
+  "datePublished": date,
+  "dateModified": date,
+  "mainEntityOfPage": canonical,
+  "description": description,
+};
 ---
 
-<Layout {title} {description} {canonical} footerSticky={false}>
+<Layout {title} {description} {canonical} footerSticky={false} schema={blogSchema}>
   <article class="max-w-4xl lg:max-w-6xl mx-auto pb-16">
     <BlogHeader 
       title={title} 

--- a/src/pages/gracias.astro
+++ b/src/pages/gracias.astro
@@ -8,7 +8,7 @@ const description = "Hemos recibido tu mensaje correctamente. Te responderemos e
 const keywords = "gracias, contacto recibido, páginas a medida";
 ---
 
-<Layout {title} {description} {keywords}>
+<Layout {title} {description} {keywords} robots="noindex,nofollow">
   <!-- Hero Section -->
   <section class="py-20 px-6 bg-gradient-to-br from-purple-900 to-slate-900 text-center">
     <div class="container mx-auto max-w-4xl">

--- a/src/pages/legal/aviso-legal.astro
+++ b/src/pages/legal/aviso-legal.astro
@@ -8,7 +8,7 @@ const description = "Aviso legal y condiciones de uso del sitio web paginasamedi
 const keywords = "aviso legal, condiciones de uso";
 ---
 
-<Layout {title} {description} {keywords}>
+<Layout {title} {description} {keywords} robots="noindex,nofollow">
   <section class="py-16 px-6 bg-white">
     <div class="container mx-auto max-w-4xl">
       <h1 class="text-3xl md:text-4xl font-bold mb-8 text-gray-800">

--- a/src/pages/legal/politica-cookies.astro
+++ b/src/pages/legal/politica-cookies.astro
@@ -8,7 +8,7 @@ const description = "Política de cookies de paginasamedida.com";
 const keywords = "política de cookies, cookies";
 ---
 
-<Layout {title} {description} {keywords}>
+<Layout {title} {description} {keywords} robots="noindex,nofollow">
   <section class="py-16 px-6 bg-white">
     <div class="container mx-auto max-w-4xl">
       <h1 class="text-3xl md:text-4xl font-bold mb-8 text-gray-800">

--- a/src/pages/legal/politica-privacidad.astro
+++ b/src/pages/legal/politica-privacidad.astro
@@ -8,7 +8,7 @@ const description = "Política de privacidad y protección de datos de paginasam
 const keywords = "política de privacidad, protección de datos";
 ---
 
-<Layout {title} {description} {keywords}>
+<Layout {title} {description} {keywords} robots="noindex,nofollow">
   <section class="py-16 px-6 bg-white">
     <div class="container mx-auto max-w-4xl">
       <h1 class="text-3xl md:text-4xl font-bold mb-8 text-gray-800">


### PR DESCRIPTION
## Summary
- add noindex/nofollow robots to thank-you and legal pages
- enrich head with OpenGraph and Twitter meta tags
- include BlogPosting schema on blog posts

## Testing
- `npm test` *(fails: Cannot find package '@astrojs/vitest')*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_689740f3d67c832c8457a08ab6fd74ad