### PR TITLE
Fix JSON-LD schema and enforce canonical redirects

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,4 @@
+# Redirect non-www and HTTP traffic to canonical HTTPS www domain
+http://paginasamedida.com/* https://www.paginasamedida.com/:splat 301!
+https://paginasamedida.com/* https://www.paginasamedida.com/:splat 301!
+http://www.paginasamedida.com/* https://www.paginasamedida.com/:splat 301!

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -75,8 +75,6 @@ if (schema) {
   <Footer sticky={footerSticky} />
 
   <!-- Schema.org JSON-LD -->
-  <script type="application/ld+json">
-    {JSON.stringify(schemaData)}
-  </script>
+  <script type="application/ld+json" set:html={JSON.stringify(schemaData)} />
 </body>
 </html>


### PR DESCRIPTION
## Summary
- render JSON-LD schema via `set:html` so Search Console reads structured data
- add Netlify `_redirects` file to force `https://www.paginasamedida.com`

## Testing
- `npm run build`
- `npm test` *(fails: Cannot find package '@astrojs/vitest')*


------
https://chatgpt.com/codex/tasks/task_e_6898e30cd45c832ca6fab0c879887b70