### PR TITLE
fix: unify canonical URLs with trailing slash

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,13 +4,14 @@ import sitemap from "@astrojs/sitemap";
 import mdx from '@astrojs/mdx';
 
 export default defineConfig({
-  site: "https://www.paginasamedida.com",
+  site: "https://www.paginasamedida.com/",
+  trailingSlash: "always",
   integrations: [
     mdx(),
-    tailwind(), 
+    tailwind(),
     sitemap({
-      filter: (page) => 
-        !page.includes('/gracias') && 
+      filter: (page) =>
+        !page.includes('/gracias') &&
         !page.includes('/legal/')
     })
   ]

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -11,20 +11,18 @@ Options -Indexes
 <IfModule mod_rewrite.c>
   RewriteEngine On
 
-  # (1) Forzar HTTPS
+  # (1) Forzar HTTPS y www
+  RewriteCond %{HTTP_HOST} !^www\.paginasamedida\.com$ [OR]
   RewriteCond %{HTTPS} off
-  RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+  RewriteRule ^(.*)$ https://www.paginasamedida.com%{REQUEST_URI} [L,R=301]
 
-  # (2) Forzar sin www (cambia si quieres con www)
-  RewriteCond %{HTTP_HOST} ^www\.paginasamedida\.com [NC]
-  RewriteRule ^(.*)$ https://paginasamedida.com/$1 [L,R=301]
-
-  # (3) Quitar barra final si no es archivo o directorio real
-  RewriteCond %{REQUEST_FILENAME} !-d
+  # (2) Añadir barra final
   RewriteCond %{REQUEST_FILENAME} !-f
-  RewriteRule ^(.+)/$ /$1 [R=301,L]
+  RewriteCond %{REQUEST_FILENAME} !-d
+  RewriteCond %{REQUEST_URI} !/$
+  RewriteRule ^(.*)$ https://www.paginasamedida.com%{REQUEST_URI}/ [L,R=301]
 
-  # (4) Prevenir hotlinking
+  # (3) Prevenir hotlinking
   RewriteCond %{HTTP_REFERER} !^$
   RewriteCond %{HTTP_REFERER} !^https://(www\.)?paginasamedida\.com [NC]
   RewriteRule \.(jpg|jpeg|png|gif|webp)$ - [NC,F,L]

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,4 +1,7 @@
-# Redirect non-www and HTTP traffic to canonical HTTPS www domain
-http://paginasamedida.com/* https://www.paginasamedida.com/:splat 301!
-https://paginasamedida.com/* https://www.paginasamedida.com/:splat 301!
-http://www.paginasamedida.com/* https://www.paginasamedida.com/:splat 301!
+# Redirect non-www and HTTP traffic to canonical HTTPS www domain with trailing slash
+http://paginasamedida.com https://www.paginasamedida.com/ 301!
+https://paginasamedida.com https://www.paginasamedida.com/ 301!
+http://www.paginasamedida.com https://www.paginasamedida.com/ 301!
+http://paginasamedida.com/* https://www.paginasamedida.com/:splat/ 301!
+https://paginasamedida.com/* https://www.paginasamedida.com/:splat/ 301!
+http://www.paginasamedida.com/* https://www.paginasamedida.com/:splat/ 301!

--- a/src/components/BlogFooter.astro
+++ b/src/components/BlogFooter.astro
@@ -40,7 +40,7 @@ const encodedTitle = encodeURIComponent(title);
   </div>
 
   <div class="mt-12 text-center">
-    <a href="/blog" class="inline-flex items-center text-purple-600 hover:text-purple-800 font-medium">
+    <a href="/blog/" class="inline-flex items-center text-purple-600 hover:text-purple-800 font-medium">
       <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
       </svg>

--- a/src/components/ContactForm.astro
+++ b/src/components/ContactForm.astro
@@ -95,7 +95,7 @@
         </div>
         
         <p class="text-xs text-gray-500 text-center mt-4">
-          Al enviar este formulario aceptas nuestra <a href="/legal/politica-privacidad" class="text-purple-600 hover:underline">Política de Privacidad</a>.
+          Al enviar este formulario aceptas nuestra <a href="/legal/politica-privacidad/" class="text-purple-600 hover:underline">Política de Privacidad</a>.
         </p>
       </form>
     </div>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -53,8 +53,8 @@ const positionClasses = sticky ? 'sticky bottom-0 left-0' : '';
         <h3 class="text-md font-semibold text-fuchsia-300 mb-3">Enlaces</h3>
         <ul class="space-y-2">
           <li><a href="/" class="text-purple-200 hover:text-white transition text-sm">Inicio</a></li>
-          <li><a href="/blog" class="text-purple-200 hover:text-white transition text-sm">Blog</a></li>
-          <li><a href="/contacto" class="text-purple-200 hover:text-white transition text-sm">Contacto</a></li>
+          <li><a href="/blog/" class="text-purple-200 hover:text-white transition text-sm">Blog</a></li>
+          <li><a href="/contacto/" class="text-purple-200 hover:text-white transition text-sm">Contacto</a></li>
         </ul>
       </div>
 
@@ -62,9 +62,9 @@ const positionClasses = sticky ? 'sticky bottom-0 left-0' : '';
       <div>
         <h3 class="text-md font-semibold text-fuchsia-300 mb-3">Legal</h3>
         <ul class="space-y-2">
-          <li><a href="/legal/aviso-legal" class="text-purple-200 hover:text-white transition text-sm">Aviso Legal</a></li>
-          <li><a href="/legal/politica-privacidad" class="text-purple-200 hover:text-white transition text-sm">Privacidad</a></li>
-          <li><a href="/legal/politica-cookies" class="text-purple-200 hover:text-white transition text-sm">Cookies</a></li>
+          <li><a href="/legal/aviso-legal/" class="text-purple-200 hover:text-white transition text-sm">Aviso Legal</a></li>
+          <li><a href="/legal/politica-privacidad/" class="text-purple-200 hover:text-white transition text-sm">Privacidad</a></li>
+          <li><a href="/legal/politica-cookies/" class="text-purple-200 hover:text-white transition text-sm">Cookies</a></li>
         </ul>
       </div>
     </div>

--- a/src/components/LatestPosts.astro
+++ b/src/components/LatestPosts.astro
@@ -121,8 +121,8 @@ const posts = (await getSortedPosts()).slice(0, 3);
     </div>
 
     <div class="text-center mt-12">
-      <a 
-        href="/blog" 
+      <a
+        href="/blog/"
         class="inline-flex items-center justify-center bg-white hover:bg-gray-50 text-purple-700 font-bold py-3 px-6 rounded-lg transition border-2 border-purple-200 shadow-sm hover:shadow-md"
       >
         Ver todos los artículos

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -42,22 +42,22 @@
             class="absolute invisible group-hover:visible opacity-0 group-hover:opacity-100 translate-y-1 group-hover:translate-y-0 bg-white shadow-lg rounded-md py-2 w-48 z-50 border border-gray-100 transition-all duration-300"
           >
             <a
-              href="/servicios/diseno-web"
+              href="/servicios/diseno-web/"
               class="block px-4 py-2 text-gray-700 hover:bg-purple-50 hover:text-purple-700"
               >Diseño Web</a
             >
             <a
-              href="/servicios/ecommerce"
+              href="/servicios/ecommerce/"
               class="block px-4 py-2 text-gray-700 hover:bg-purple-50 hover:text-purple-700"
               >E-commerce</a
             >
             <a
-              href="/servicios/seo"
+              href="/servicios/seo/"
               class="block px-4 py-2 text-gray-700 hover:bg-purple-50 hover:text-purple-700"
               >SEO</a
             >
             <a
-              href="/servicios/ads"
+              href="/servicios/ads/"
               class="block px-4 py-2 text-gray-700 hover:bg-purple-50 hover:text-purple-700"
               >Publicidad (ADS)</a
             >
@@ -65,14 +65,14 @@
         </div>
 
         <a
-          href="/sobre-mi"
+          href="/sobre-mi/"
           class="text-gray-700 hover:text-purple-700 transition">Sobre Mí</a
         >
-        <a href="/blog" class="text-gray-700 hover:text-purple-700 transition"
+        <a href="/blog/" class="text-gray-700 hover:text-purple-700 transition"
           >Blog</a
         >
         <a
-          href="/contacto"
+          href="/contacto/"
           class="text-gray-700 hover:text-purple-700 transition">Contacto</a
         >
       </div>
@@ -122,34 +122,34 @@
         </button>
         <div id="mobile-services-menu" class="hidden pl-4">
           <a
-            href="/servicios/diseno-web"
+            href="/servicios/diseno-web/"
             class="block py-2 text-gray-700 hover:text-purple-700"
             >Diseño Web</a
           >
           <a
-            href="/servicios/ecommerce"
+            href="/servicios/ecommerce/"
             class="block py-2 text-gray-700 hover:text-purple-700"
             >E-commerce</a
           >
           <a
-            href="/servicios/seo"
+            href="/servicios/seo/"
             class="block py-2 text-gray-700 hover:text-purple-700"
             >SEO</a
           >
           <a
-            href="/servicios/ads"
+            href="/servicios/ads/"
             class="block py-2 text-gray-700 hover:text-purple-700"
             >Publicidad (ADS)</a
           >
         </div>
       </div>
-      <a href="/sobre-mi" class="block py-2 text-gray-700 hover:text-purple-700"
+      <a href="/sobre-mi/" class="block py-2 text-gray-700 hover:text-purple-700"
         >Sobre Mí</a
       >
-      <a href="/blog" class="block py-2 text-gray-700 hover:text-purple-700"
+      <a href="/blog/" class="block py-2 text-gray-700 hover:text-purple-700"
         >Blog</a
       >
-      <a href="/contacto" class="block py-2 text-gray-700 hover:text-purple-700"
+      <a href="/contacto/" class="block py-2 text-gray-700 hover:text-purple-700"
         >Contacto</a
       >
     </div>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -8,7 +8,10 @@ import '../styles/global.css';
 const {
   title,
   description,
-  canonical = new URL(Astro.url.pathname, Astro.site).toString(),
+  canonical = new URL(
+    Astro.url.pathname.endsWith('/') ? Astro.url.pathname : Astro.url.pathname + '/',
+    Astro.site
+  ).toString(),
   image = new URL('/images/og-image.jpg', Astro.site).toString(),
   robots = 'index,follow',
   keywords,

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -6,8 +6,8 @@ const title = "404 - Página no encontrada";
 const description = "La página que buscas no existe en nuestro sitio";
 const errorLinks = [
   { text: "Inicio", url: "/" },
-  { text: "Blog", url: "/blog" },
-  { text: "Contacto", url: "/contacto" }
+  { text: "Blog", url: "/blog/" },
+  { text: "Contacto", url: "/contacto/" }
 ];
 ---
 <Layout {title} {description}>
@@ -60,7 +60,7 @@ const errorLinks = [
         <div class="bg-amber-50 rounded-xl border-l-4 border-purple-600 p-6 text-left">
           <h3 class="font-bold text-gray-800 mb-2">¿Buscas algo específico?</h3>
           <p class="text-gray-600">
-            Si no encuentras lo que necesitas, no dudes en <a href="/contacto" class="text-purple-600 hover:underline">contactarme</a> directamente. 
+            Si no encuentras lo que necesitas, no dudes en <a href="/contacto/" class="text-purple-600 hover:underline">contactarme</a> directamente.
             Estaré encantado de ayudarte.
           </p>
         </div>
@@ -78,7 +78,7 @@ const errorLinks = [
         Trabajemos juntos para crear soluciones digitales efectivas
       </p>
       <a
-        href="/contacto"
+        href="/contacto/"
         class="inline-block bg-white hover:bg-gray-100 text-purple-900 font-bold py-3 px-8 rounded-lg transition shadow-lg hover:shadow-xl"
       >
         Contactar ahora

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -18,7 +18,10 @@ const { post } = Astro.props as {
 };
 const { Content, headings } = await post.render();
 const { title, description, date, image, readingTime } = post.data;
-const canonical = new URL(Astro.url.pathname, Astro.site).toString();
+const canonical = new URL(
+  Astro.url.pathname.endsWith('/') ? Astro.url.pathname : Astro.url.pathname + '/',
+  Astro.site
+).toString();
 const blogSchema = {
   "@context": "https://schema.org",
   "@type": "BlogPosting",

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -9,7 +9,10 @@ const totalPages = Math.ceil(posts.length / postsPerPage);
 const currentPage = 1;
 const title = "Blog | Páginas a Medida";
 const description = "Artículos y consejos sobre desarrollo web, SEO y tecnología.";
-const canonical = new URL(Astro.url.pathname, Astro.site).toString();
+const canonical = new URL(
+  Astro.url.pathname.endsWith('/') ? Astro.url.pathname : Astro.url.pathname + '/',
+  Astro.site
+).toString();
 const keywords = "blog, desarrollo web, seo, tecnología";
 ---
 

--- a/src/pages/blog/page/[page].astro
+++ b/src/pages/blog/page/[page].astro
@@ -26,7 +26,10 @@ const { pagePosts, totalPages, currentPage } = Astro.props as {
 };
 const title = `Blog página ${currentPage} | Páginas a Medida`;
 const description = "Artículos y consejos sobre desarrollo web, SEO y tecnología.";
-const canonical = new URL(Astro.url.pathname, Astro.site).toString();
+const canonical = new URL(
+  Astro.url.pathname.endsWith('/') ? Astro.url.pathname : Astro.url.pathname + '/',
+  Astro.site
+).toString();
 const keywords = "blog, desarrollo web, seo, tecnología";
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1126,7 +1126,7 @@ import LatestPosts from "../components/LatestPosts.astro";
             necesitan presencia profesional.
           </p>
           <a
-            href="/contacto"
+            href="/contacto/"
             class="text-fuchsia-600 hover:text-fuchsia-700 font-medium flex items-center gap-1"
           >
             Saber más
@@ -1171,7 +1171,7 @@ import LatestPosts from "../components/LatestPosts.astro";
             vender 24/7.
           </p>
           <a
-            href="/servicios/ecommerce"
+            href="/servicios/ecommerce/"
             class="text-fuchsia-600 hover:text-fuchsia-700 font-medium flex items-center gap-1"
           >
             Saber más
@@ -1218,7 +1218,7 @@ import LatestPosts from "../components/LatestPosts.astro";
             resultados de búsqueda.
           </p>
           <a
-            href="/servicios/seo"
+            href="/servicios/seo/"
             class="text-fuchsia-600 hover:text-fuchsia-700 font-medium flex items-center gap-1"
           >
             Saber más

--- a/src/pages/sobre-mi.astro
+++ b/src/pages/sobre-mi.astro
@@ -242,7 +242,7 @@ const keywords = "ingeniero informático, desarrollo web, análisis de datos";
         a resultados.
       </p>
       <a
-        href="/contacto"
+        href="/contacto/"
         class="inline-block bg-white hover:bg-gray-100 text-purple-900 font-bold py-3 px-8 rounded-lg transition shadow-lg hover:shadow-xl"
       >
         Habla conmigo directamente


### PR DESCRIPTION
## Summary
- enforce https://www.paginasamedida.com/ as canonical site with trailing slash
- align .htaccess and Netlify redirects with canonical www domain
- normalize internal links to include trailing slash

## Testing
- `npm test` *(fails: Cannot find package '@astrojs/vitest')*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_6898fc064324832cbb8a126e857462cd