### PR TITLE
Remove site suffix from page titles

### DIFF
--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -7,7 +7,7 @@ const postsPerPage = 6;
 const pagePosts = posts.slice(0, postsPerPage);
 const totalPages = Math.ceil(posts.length / postsPerPage);
 const currentPage = 1;
-const title = "Blog | Páginas a Medida";
+const title = "Blog";
 const description = "Artículos y consejos sobre desarrollo web, SEO y tecnología.";
 const canonical = new URL(
   Astro.url.pathname.endsWith('/') ? Astro.url.pathname : Astro.url.pathname + '/',

--- a/src/pages/blog/page/[page].astro
+++ b/src/pages/blog/page/[page].astro
@@ -24,7 +24,7 @@ const { pagePosts, totalPages, currentPage } = Astro.props as {
   totalPages: number;
   currentPage: number;
 };
-const title = `Blog página ${currentPage} | Páginas a Medida`;
+const title = `Blog página ${currentPage}`;
 const description = "Artículos y consejos sobre desarrollo web, SEO y tecnología.";
 const canonical = new URL(
   Astro.url.pathname.endsWith('/') ? Astro.url.pathname : Astro.url.pathname + '/',

--- a/src/pages/contacto.astro
+++ b/src/pages/contacto.astro
@@ -3,7 +3,7 @@
 import Layout from "../layouts/Layout.astro";
 import ContactForm from "../components/ContactForm.astro";
 
-const title = "Contacto | Páginas a Medida";
+const title = "Contacto";
 const description = "Contacta con nuestro equipo para desarrollar tu proyecto web. Teléfono, WhatsApp, email o formulario de contacto.";
 const keywords = "contacto, desarrollo web, páginas a medida";
 ---

--- a/src/pages/gracias.astro
+++ b/src/pages/gracias.astro
@@ -3,7 +3,7 @@
 import Layout from "../layouts/Layout.astro";
 sitemap: false
 
-const title = "¡Gracias por contactarnos! | Páginas a Medida";
+const title = "¡Gracias por contactarnos!";
 const description = "Hemos recibido tu mensaje correctamente. Te responderemos en breve.";
 const keywords = "gracias, contacto recibido, páginas a medida";
 ---

--- a/src/pages/servicios/ads.astro
+++ b/src/pages/servicios/ads.astro
@@ -3,7 +3,7 @@
 import Layout from "../../layouts/Layout.astro";
 import ContactForm from "../../components/ContactForm.astro";
 
-const title = "Publicidad Digital Profesional | Páginas a Medida";
+const title = "Publicidad Digital Profesional";
 const description =
   "Gestión experta de campañas digitales en Google Ads, Meta Ads y más. Maximizamos tu inversión publicitaria con estrategias data-driven.";
 const keywords = "publicidad digital, google ads, meta ads";

--- a/src/pages/servicios/diseno-web.astro
+++ b/src/pages/servicios/diseno-web.astro
@@ -4,7 +4,7 @@ import Layout from "../../layouts/Layout.astro";
 import ContactForm from "../../components/ContactForm.astro";
 import BeneficioItem from "../../components/BeneficioItem.astro";
 
-const title = "Diseño Web Profesional | Páginas a Medida";
+const title = "Diseño Web Profesional";
 const description =
   "Desarrollo de páginas web estáticas y dinámicas ultra rápidas con Astro y Tailwind, optimizadas para SEO y conversión.";
 const keywords = "diseño web, desarrollo web a medida, astro, tailwind";

--- a/src/pages/servicios/ecommerce.astro
+++ b/src/pages/servicios/ecommerce.astro
@@ -5,7 +5,7 @@ import ContactForm from "../../components/ContactForm.astro";
 import PlatformCard from "../../components/PlatformCard.astro";
 import FeatureCard from "../../components/FeatureCard.astro";
 
-const title = "Desarrollo Ecommerce Profesional | Páginas a Medida";
+const title = "Desarrollo Ecommerce Profesional";
 const description =
   "Tiendas online a medida con Shopify, PrestaShop o WooCommerce. Soluciones optimizadas para conversión y gestión sencilla.";
 const keywords = "tiendas online, ecommerce, shopify, prestashop, woocommerce";

--- a/src/pages/servicios/seo.astro
+++ b/src/pages/servicios/seo.astro
@@ -3,7 +3,7 @@
 import Layout from "../../layouts/Layout.astro";
 import ContactForm from "../../components/ContactForm.astro";
 
-const title = "Posicionamiento SEO Profesional | Páginas a Medida";
+const title = "Posicionamiento SEO Profesional";
 const description =
   "SEO técnico y de contenido para negocios locales. Webs optimizadas para aparecer en Google cuando tus clientes te buscan.";
 const keywords = "seo, posicionamiento web, marketing digital";


### PR DESCRIPTION
## Summary
- remove site name from `title` constants on contact, thanks, service, and blog pages

## Testing
- `npm test` *(fails: Cannot find package '@astrojs/vitest')*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_6899dc23c310832c8b5d768176319774