### PR TITLE
chore: replace robots header directive

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -53,7 +53,7 @@ Options -Indexes
 </FilesMatch>
 
 # 7. No indexar páginas legales
-<FilesMatch "(gracias|aviso-legal|politica-privacidad|politica-cookies)(\.html)?$">
+<LocationMatch "^/(gracias|legal/(aviso-legal|politica-privacidad|politica-cookies))/">
   Header set X-Robots-Tag "noindex, nofollow"
-</FilesMatch>
+</LocationMatch>
 


### PR DESCRIPTION
## Summary
- use `LocationMatch` for legal pages robots header

## Testing
- `npm test` *(fails: Cannot find package '@astrojs/vitest')*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_6899dd9e12d8832c895fcc24da34ef17