### PR TITLE
Improve accessibility and contrast for buttons

### DIFF
--- a/src/components/ContactForm.astro
+++ b/src/components/ContactForm.astro
@@ -94,8 +94,14 @@
           </button>
         </div>
         
-        <p class="text-xs text-gray-500 text-center mt-4">
-          Al enviar este formulario aceptas nuestra <a href="/legal/politica-privacidad/" class="text-purple-600 hover:underline">Política de Privacidad</a>.
+        <p class="text-xs text-gray-700 text-center mt-4">
+          Al enviar este formulario aceptas nuestra
+          <a
+            href="/legal/politica-privacidad/"
+            class="text-purple-800 hover:text-purple-900 hover:underline"
+          >
+            Política de Privacidad
+          </a>.
         </p>
       </form>
     </div>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -78,7 +78,11 @@
       </div>
 
       <!-- Botón Hamburguesa (solo móvil) -->
-      <button class="md:hidden text-gray-700 focus:outline-none" id="menu-btn">
+      <button
+        class="md:hidden text-gray-700 focus:outline-none"
+        id="menu-btn"
+        aria-label="Abrir menú de navegación"
+      >
         <svg
           class="w-6 h-6"
           fill="none"

--- a/src/pages/contacto.astro
+++ b/src/pages/contacto.astro
@@ -48,7 +48,10 @@ const keywords = "contacto, desarrollo web, páginas a medida";
           </div>
           <h3 class="text-xl font-bold mb-3 text-gray-800">Escríbeme por WhatsApp</h3>
           <p class="text-gray-600 mb-4">Resuelve tus dudas al instante</p>
-          <a href="https://wa.me/34623962963" class="inline-block bg-green-500 hover:bg-green-600 text-white font-medium py-2 px-6 rounded-lg transition">
+          <a
+            href="https://wa.me/34623962963"
+            class="inline-block bg-green-600 hover:bg-green-700 text-white font-medium py-2 px-6 rounded-lg transition"
+          >
             Abrir WhatsApp
           </a>
         </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -53,7 +53,7 @@ import LatestPosts from "../components/LatestPosts.astro";
 
         <a
           href="https://wa.me/34623962963"
-          class="bg-emerald-500 hover:bg-emerald-600 text-white font-bold py-3 px-6 rounded-lg transition flex items-center gap-2"
+          class="bg-emerald-600 hover:bg-emerald-700 text-white font-bold py-3 px-6 rounded-lg transition flex items-center gap-2"
         >
           <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
             <path


### PR DESCRIPTION
## Summary
- ensure mobile menu button has an accessible label
- increase contrast for privacy notice text and link
- darken WhatsApp buttons to maintain brand while meeting contrast guidelines

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm test` *(fails: Cannot find package '@astrojs/vitest')*
- `npx prettier --write src/components/Nav.astro src/components/ContactForm.astro src/pages/index.astro src/pages/contacto.astro` *(fails: No parser could be inferred for .astro files)*

------
https://chatgpt.com/codex/tasks/task_e_6899dff90f0c832cb756766f6d63b4db