### PR TITLE
Fix GTM script to define GTM_ID inline

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -73,7 +73,7 @@ if (schema) {
     {type}
     siteName={siteName}
   />
-    <script>
+    <script is:inline>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('consent','default',{
@@ -83,7 +83,8 @@ if (schema) {
       ad_personalization:'denied'
     });
   </script>
-  <script>
+  <script is:inline>
+    const GTM_ID = {JSON.stringify(GTM_ID)};
     (function(w,d,s,l,i){
       w[l]=w[l]||[];
       w[l].push({'gtm.start': new Date().getTime(), event:'gtm.js'});


### PR DESCRIPTION
## Summary
- Inline GTM loader script and inject GTM_ID from environment to prevent ReferenceError

## Testing
- `npm test` *(fails: Cannot find package '@astrojs/vitest')*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_689b521ad2d8832c904dc4a51b8b8e2b