### PR TITLE
Fix GTM inline script and add Alpine collapse plugin

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -45,5 +45,6 @@ const {
 
   <!-- Alpine JS -->
   <script defer src="https://unpkg.com/@alpinejs/intersect@3.x.x/dist/cdn.min.js"></script>
+  <script defer src="https://unpkg.com/@alpinejs/collapse@3.x.x/dist/cdn.min.js"></script>
   <script src="https://unpkg.com/alpinejs" defer></script>
 </Fragment>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -84,17 +84,17 @@ if (schema) {
     });
   </script>
   <script is:inline>
-    const GTM_ID = {JSON.stringify(GTM_ID)};
-    (function(w,d,s,l,i){
-      w[l]=w[l]||[];
-      w[l].push({'gtm.start': new Date().getTime(), event:'gtm.js'});
-      var f=d.getElementsByTagName(s)[0],
-          j=d.createElement(s),
-          dl=l!='dataLayer'? '&l='+l : '';
-      j.async=true;
-      j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
-      f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer', GTM_ID);
+    const GTM_ID = ${JSON.stringify(GTM_ID)};
+    (function (w, d, s, l, i) {
+      w[l] = w[l] || [];
+      w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+      const f = d.getElementsByTagName(s)[0],
+        j = d.createElement(s),
+        dl = l != 'dataLayer' ? '&l=' + l : '';
+      j.async = true;
+      j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+      f.parentNode.insertBefore(j, f);
+    })(window, document, 'script', 'dataLayer', GTM_ID);
   </script>
 </head>
 <body class="bg-white text-gray-800 min-h-screen flex flex-col relative">


### PR DESCRIPTION
## Summary
- Fix GTM inline script generation to avoid syntax error
- Include Alpine `collapse` plugin to remove x-collapse warnings

## Testing
- `npm run lint` *(fails: ESLint couldn't find eslint.config)*
- `npm test` *(fails: Cannot find package '@astrojs/vitest')*


------
https://chatgpt.com/codex/tasks/task_e_689b546c41fc832c8cfe969bd83b35e9