### PR TITLE
Use interpolated env IDs for GTM and GA4

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -9,8 +9,19 @@ import '../styles/global.css';
 const GTM_ID = import.meta.env.PUBLIC_GTM_ID;
 const GA4_ID = import.meta.env.PUBLIC_GA4_ID; // usable inside GTM configuration
 
-const gtmScript = `
+const analyticsScript = `
   const GTM_ID = ${JSON.stringify(GTM_ID)};
+  const GA4_ID = ${JSON.stringify(GA4_ID)};
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('consent','default',{
+    ad_storage:'denied',
+    analytics_storage:'denied',
+    ad_user_data:'denied',
+    ad_personalization:'denied'
+  });
+  gtag('js', new Date());
+  gtag('config', GA4_ID);
   (function (w, d, s, l, i) {
     w[l] = w[l] || [];
     w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
@@ -87,22 +98,13 @@ if (schema) {
     {type}
     siteName={siteName}
   />
-    <script is:inline>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('consent','default',{
-      ad_storage:'denied',
-      analytics_storage:'denied',
-      ad_user_data:'denied',
-      ad_personalization:'denied'
-    });
-  </script>
-  <script is:inline set:html={gtmScript} />
+  <script async src={`https://www.googletagmanager.com/gtag/js?id=${GA4_ID}`}></script>
+  <script is:inline set:html={analyticsScript} />
 </head>
 <body class="bg-white text-gray-800 min-h-screen flex flex-col relative">
   <noscript>
     <iframe
-      src={"https://www.googletagmanager.com/ns.html?id=" + GTM_ID}
+      src={`https://www.googletagmanager.com/ns.html?id=${GTM_ID}`}
       height="0"
       width="0"
       style="display:none;visibility:hidden"


### PR DESCRIPTION
## Summary
- Read PUBLIC_GTM_ID and PUBLIC_GA4_ID in Layout frontmatter
- Inject IDs into analytics script and noscript using Astro interpolation so build outputs real values

## Testing
- `npm test` *(fails: Cannot find package '@astrojs/vitest')*
- `npm install @astrojs/vitest --no-save` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b5f776d94832c8792a0e6f0b04e4f