### PR TITLE
fix: show full blog pagination

### DIFF
--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,5 +1,8 @@
 import { getCollection, type CollectionEntry } from 'astro:content';
 
+// Número de publicaciones a mostrar por página en el blog
+export const POSTS_PER_PAGE = 6;
+
 export async function getSortedPosts(): Promise<CollectionEntry<'blog'>[]> {
   const posts = await getCollection('blog');
   return posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime());

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,9 +1,9 @@
 ---
 import Layout from "../../layouts/Layout.astro";
-import { getSortedPosts } from "../../lib/posts";
+import { getSortedPosts, POSTS_PER_PAGE } from "../../lib/posts";
 
 const posts = await getSortedPosts();
-const postsPerPage = 6;
+const postsPerPage = POSTS_PER_PAGE;
 const pagePosts = posts.slice(0, postsPerPage);
 const totalPages = Math.ceil(posts.length / postsPerPage);
 const currentPage = 1;
@@ -83,27 +83,25 @@ const keywords = "blog, desarrollo web, seo, tecnología";
       </div>
 
       <!-- Paginación mejorada -->
-      {totalPages > 1 && (
-        <nav class="flex justify-center mt-16" aria-label="Paginación">
-          <ul class="inline-flex items-center gap-2">
-            {Array.from({ length: totalPages }).map((_, i) => (
-              <li>
-                <a
-                  href={i === 0 ? '/blog/' : `/blog/page/${i + 1}/`}
-                  class={`flex items-center justify-center w-10 h-10 rounded-full font-medium transition ${
-                    i + 1 === currentPage
-                      ? 'bg-gradient-to-r from-fuchsia-600 to-purple-600 text-white shadow-md'
-                      : 'text-gray-700 hover:bg-gray-100'
-                  }`}
-                  aria-current={i + 1 === currentPage ? 'page' : undefined}
-                >
-                  {i + 1}
-                </a>
-              </li>
-            ))}
-          </ul>
-        </nav>
-      )}
+      <nav class="flex justify-center mt-16" aria-label="Paginación">
+        <ul class="inline-flex items-center gap-2">
+          {Array.from({ length: totalPages }).map((_, i) => (
+            <li>
+              <a
+                href={i === 0 ? '/blog/' : `/blog/page/${i + 1}/`}
+                class={`flex items-center justify-center w-10 h-10 rounded-full font-medium transition ${
+                  i + 1 === currentPage
+                    ? 'bg-gradient-to-r from-fuchsia-600 to-purple-600 text-white shadow-md'
+                    : 'text-gray-700 hover:bg-gray-100'
+                }`}
+                aria-current={i + 1 === currentPage ? 'page' : undefined}
+              >
+                {i + 1}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
     </div>
   </section>
 

--- a/src/pages/blog/page/[page].astro
+++ b/src/pages/blog/page/[page].astro
@@ -1,10 +1,10 @@
 ---
 import Layout from "../../../layouts/Layout.astro";
-import { getSortedPosts } from "../../../lib/posts";
+import { getSortedPosts, POSTS_PER_PAGE } from "../../../lib/posts";
 
 export async function getStaticPaths() {
   const posts = await getSortedPosts();
-  const postsPerPage = 6;
+  const postsPerPage = POSTS_PER_PAGE;
   const totalPages = Math.ceil(posts.length / postsPerPage);
   return Array.from({ length: totalPages }, (_, i) => {
     const start = i * postsPerPage;
@@ -55,19 +55,17 @@ const keywords = "blog, desarrollo web, seo, tecnología";
           </li>
         ))}
       </ul>
-      {totalPages > 1 && (
-        <nav class="flex justify-center mt-12 gap-4">
-          {Array.from({ length: totalPages }).map((_, i) => (
-            <a
-              href={i === 0 ? '/blog/' : `/blog/page/${i + 1}/`}
-              class={`px-4 py-2 rounded ${i + 1 === currentPage ? 'bg-purple-600 text-white' : 'bg-gray-200 text-gray-700 hover:bg-gray-300'}`}
-              aria-current={i + 1 === currentPage ? 'page' : undefined}
-            >
-              {i + 1}
-            </a>
-          ))}
-        </nav>
-      )}
+      <nav class="flex justify-center mt-12 gap-4">
+        {Array.from({ length: totalPages }).map((_, i) => (
+          <a
+            href={i === 0 ? '/blog/' : `/blog/page/${i + 1}/`}
+            class={`px-4 py-2 rounded ${i + 1 === currentPage ? 'bg-purple-600 text-white' : 'bg-gray-200 text-gray-700 hover:bg-gray-300'}`}
+            aria-current={i + 1 === currentPage ? 'page' : undefined}
+          >
+            {i + 1}
+          </a>
+        ))}
+      </nav>
     </div>
   </section>
 </Layout>


### PR DESCRIPTION
## Summary
- centralize blog pagination size and expose POSTS_PER_PAGE constant
- always display page navigation for blog index and paginated pages

## Testing
- `npm test` (fails: Cannot find package '@astrojs/vitest')
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1d95f8fcc832c9ebc0addfd8e19c0